### PR TITLE
Development

### DIFF
--- a/public/translations/ar/default.json
+++ b/public/translations/ar/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "الصفحة {{page}} (الحالية)",
   "pagination.pageLabel": "صفحة",
   "archive": "الأرشيف",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "بحث عن OPs...",
   "private_key_warning_title": "تحذير المفتاح الخاص",
   "private_key_warning_description": "يعرض هذا المحرر المفتاح الخاص لحسابك. لا تشارك هذه البيانات مع أي شخص. التحرير بشكل خاطئ قد يكسر حسابك.",
   "go_back": "رجوع",

--- a/public/translations/bn/default.json
+++ b/public/translations/bn/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "পৃষ্ঠা {{page}} (বর্তমান)",
   "pagination.pageLabel": "পৃষ্ঠা",
   "archive": "সংরক্ষণাগার",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs অনুসন্ধান...",
   "private_key_warning_title": "প্রাইভেট কী সতর্কতা",
   "private_key_warning_description": "এই সম্পাদক আপনার অ্যাকাউন্টের প্রাইভেট কী দেখায়। এই ডেটা কারও সাথে শেয়ার করবেন না। ভুলভাবে সম্পাদনা করলে আপনার অ্যাকাউন্ট ক্ষতিগ্রস্ত হতে পারে।",
   "go_back": "ফিরে যান",

--- a/public/translations/cs/default.json
+++ b/public/translations/cs/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Stránka {{page}} (aktuální)",
   "pagination.pageLabel": "Stránka",
   "archive": "Archiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Hledat OPs...",
   "private_key_warning_title": "Varování o privátním klíči",
   "private_key_warning_description": "Tento editor zobrazuje soukromý klíč vašeho účtu. Tyto údaje nikomu nesdílejte. Nesprávná úprava může váš účet poškodit.",
   "go_back": "Zpět",

--- a/public/translations/da/default.json
+++ b/public/translations/da/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Side {{page}} (nuværende)",
   "pagination.pageLabel": "Side",
   "archive": "Arkiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Søg OPs...",
   "private_key_warning_title": "Advarsel om privat nøgle",
   "private_key_warning_description": "Denne editor viser din kontos private nøgle. Del ikke disse data med nogen. Forkert redigering kan ødelægge din konto.",
   "go_back": "Gå tilbage",

--- a/public/translations/de/default.json
+++ b/public/translations/de/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Seite {{page}} (aktuell)",
   "pagination.pageLabel": "Seite",
   "archive": "Archiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs suchen...",
   "private_key_warning_title": "Warnung zum privaten Schlüssel",
   "private_key_warning_description": "Dieser Editor zeigt den privaten Schlüssel Ihres Kontos an. Teilen Sie diese Daten mit niemandem. Falsche Bearbeitung kann Ihr Konto beschädigen.",
   "go_back": "Zurück",

--- a/public/translations/el/default.json
+++ b/public/translations/el/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Σελίδα {{page}} (τρέχουσα)",
   "pagination.pageLabel": "Σελίδα",
   "archive": "Αρχείο",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Αναζήτηση OPs...",
   "private_key_warning_title": "Προειδοποίηση ιδιωτικού κλειδιού",
   "private_key_warning_description": "Αυτό το πρόγραμμα επεξεργασίας εμφανίζει το ιδιωτικό κλειδί του λογαριασμού σας. Μην μοιράζεστε αυτά τα δεδομένα με κανέναν. Η λανθασμένη επεξεργασία μπορεί να καταστρέψει τον λογαριασμό σας.",
   "go_back": "Επιστροφή",

--- a/public/translations/es/default.json
+++ b/public/translations/es/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Página {{page}} (actual)",
   "pagination.pageLabel": "Página",
   "archive": "Archivo",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Buscar OPs...",
   "private_key_warning_title": "Advertencia de clave privada",
   "private_key_warning_description": "Este editor muestra la clave privada de tu cuenta. No compartas estos datos con nadie. Editar incorrectamente puede dañar tu cuenta.",
   "go_back": "Volver",

--- a/public/translations/fa/default.json
+++ b/public/translations/fa/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "صفحه {{page}} (فعلی)",
   "pagination.pageLabel": "صفحه",
   "archive": "بایگانی",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "جستجوی OPs...",
   "private_key_warning_title": "هشدار کلید خصوصی",
   "private_key_warning_description": "این ویرایشگر کلید خصوصی حساب شما را نمایش می‌دهد. این داده‌ها را با هیچ‌کس به اشتراک نگذارید. ویرایش نادرست ممکن است حساب شما را خراب کند.",
   "go_back": "بازگشت",

--- a/public/translations/fi/default.json
+++ b/public/translations/fi/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Sivu {{page}} (nykyinen)",
   "pagination.pageLabel": "Sivu",
   "archive": "Arkisto",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Hae OPs...",
   "private_key_warning_title": "Yksityisen avaimen varoitus",
   "private_key_warning_description": "Tämä editori näyttää tilisi yksityisen avaimen. Älä jaa näitä tietoja kenenkään kanssa. Virheellinen muokkaus voi rikkoa tilisi.",
   "go_back": "Takaisin",

--- a/public/translations/fil/default.json
+++ b/public/translations/fil/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Pahina {{page}} (kasalukuyan)",
   "pagination.pageLabel": "Pahina",
   "archive": "Arkibo",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Maghanap ng OPs...",
   "private_key_warning_title": "Babala sa Pribadong Susi",
   "private_key_warning_description": "Ang editor na ito ay nagpapakita ng pribadong susi ng iyong account. Huwag ibahagi ang data na ito sa sinuman. Ang maling pag-edit ay maaaring masira ang iyong account.",
   "go_back": "Bumalik",

--- a/public/translations/fr/default.json
+++ b/public/translations/fr/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Page {{page}} (actuelle)",
   "pagination.pageLabel": "Page",
   "archive": "Archives",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Rechercher OPs...",
   "private_key_warning_title": "Avertissement concernant la clé privée",
   "private_key_warning_description": "Cet éditeur affiche la clé privée de votre compte. Ne partagez pas ces données avec qui que ce soit. Une modification incorrecte peut endommager votre compte.",
   "go_back": "Retour",

--- a/public/translations/he/default.json
+++ b/public/translations/he/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "עמוד {{page}} (נוכחי)",
   "pagination.pageLabel": "עמוד",
   "archive": "ארכיון",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "חפש OPs...",
   "private_key_warning_title": "אזהרת מפתח פרטי",
   "private_key_warning_description": "עורך זה מציג את המפתח הפרטי של חשבונך. אל תשתף נתונים אלה עם אף אחד. עריכה שגויה עלולה לשבור את חשבונך.",
   "go_back": "חזור",

--- a/public/translations/hi/default.json
+++ b/public/translations/hi/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "पृष्ठ {{page}} (वर्तमान)",
   "pagination.pageLabel": "पृष्ठ",
   "archive": "संग्रह",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs खोजें...",
   "private_key_warning_title": "निजी कुंजी चेतावनी",
   "private_key_warning_description": "यह संपादक आपके खाते की निजी कुंजी दिखाता है। इस डेटा को किसी के साथ साझा न करें। गलत तरीके से संपादन करने से आपका खाता खराब हो सकता है।",
   "go_back": "वापस जाएं",

--- a/public/translations/hu/default.json
+++ b/public/translations/hu/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "{{page}}. oldal (jelenlegi)",
   "pagination.pageLabel": "Oldal",
   "archive": "Archívum",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs keresése...",
   "private_key_warning_title": "Privát kulcs figyelmeztetés",
   "private_key_warning_description": "Ez a szerkesztő megjeleníti fiókod titkos kulcsát. Ne osszd meg ezeket az adatokat senkivel. A helytelen szerkesztés tönkreteheti a fiókodat.",
   "go_back": "Vissza",

--- a/public/translations/id/default.json
+++ b/public/translations/id/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Halaman {{page}} (saat ini)",
   "pagination.pageLabel": "Halaman",
   "archive": "Arsip",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Cari OPs...",
   "private_key_warning_title": "Peringatan Kunci Privat",
   "private_key_warning_description": "Editor ini menampilkan kunci pribadi akun Anda. Jangan bagikan data ini kepada siapa pun. Mengedit dengan salah dapat merusak akun Anda.",
   "go_back": "Kembali",

--- a/public/translations/it/default.json
+++ b/public/translations/it/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Pagina {{page}} (corrente)",
   "pagination.pageLabel": "Pagina",
   "archive": "Archivio",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Cerca OPs...",
   "private_key_warning_title": "Avviso chiave privata",
   "private_key_warning_description": "Questo editor mostra la chiave privata del tuo account. Non condividere questi dati con nessuno. Modifiche errate potrebbero compromettere il tuo account.",
   "go_back": "Indietro",

--- a/public/translations/ja/default.json
+++ b/public/translations/ja/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "{{page}}ページ（現在）",
   "pagination.pageLabel": "ページ",
   "archive": "アーカイブ",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPsを検索...",
   "private_key_warning_title": "秘密鍵の警告",
   "private_key_warning_description": "このエディターはアカウントの秘密鍵を表示します。このデータを誰とも共有しないでください。誤った編集によりアカウントが破損する可能性があります。",
   "go_back": "戻る",

--- a/public/translations/ko/default.json
+++ b/public/translations/ko/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "{{page}}페이지 (현재)",
   "pagination.pageLabel": "페이지",
   "archive": "아카이브",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs 검색...",
   "private_key_warning_title": "개인 키 경고",
   "private_key_warning_description": "이 편집기는 계정의 개인 키를 표시합니다. 이 데이터를 누구와도 공유하지 마세요. 잘못된 편집은 계정을 손상시킬 수 있습니다.",
   "go_back": "돌아가기",

--- a/public/translations/mr/default.json
+++ b/public/translations/mr/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "पृष्ठ {{page}} (वर्तमान)",
   "pagination.pageLabel": "पृष्ठ",
   "archive": "संग्रह",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs शोधा...",
   "private_key_warning_title": "खाजगी कुंजी चेतावनी",
   "private_key_warning_description": "हा संपादक तुमच्या खात्याची खाजगी की दर्शवतो. हा डेटा कोणाशीही सामायिक करू नका. चुकीच्या संपादनामुळे तुमचे खाते बिघडू शकते.",
   "go_back": "मागे जा",

--- a/public/translations/nl/default.json
+++ b/public/translations/nl/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Pagina {{page}} (huidige)",
   "pagination.pageLabel": "Pagina",
   "archive": "Archief",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Zoek OPs...",
   "private_key_warning_title": "Waarschuwing privésleutel",
   "private_key_warning_description": "Deze editor toont de privésleutel van je account. Deel deze gegevens met niemand. Onjuiste bewerking kan je account beschadigen.",
   "go_back": "Terug",

--- a/public/translations/no/default.json
+++ b/public/translations/no/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Side {{page}} (nåværende)",
   "pagination.pageLabel": "Side",
   "archive": "Arkiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Søk OPs...",
   "private_key_warning_title": "Advarsel om privat nøkkel",
   "private_key_warning_description": "Denne editoren viser kontoens private nøkkel. Ikke del disse dataene med noen. Feil redigering kan ødelegge kontoen din.",
   "go_back": "Gå tilbake",

--- a/public/translations/pl/default.json
+++ b/public/translations/pl/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Strona {{page}} (bieżąca)",
   "pagination.pageLabel": "Strona",
   "archive": "Archiwum",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Szukaj OPs...",
   "private_key_warning_title": "Ostrzeżenie o kluczu prywatnym",
   "private_key_warning_description": "Ten edytor wyświetla klucz prywatny Twojego konta. Nie udostępniaj tych danych nikomu. Nieprawidłowa edycja może uszkodzić Twoje konto.",
   "go_back": "Wróć",

--- a/public/translations/pt/default.json
+++ b/public/translations/pt/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Página {{page}} (atual)",
   "pagination.pageLabel": "Página",
   "archive": "Arquivo",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Pesquisar OPs...",
   "private_key_warning_title": "Aviso de chave privada",
   "private_key_warning_description": "Este editor mostra a chave privada da sua conta. Não compartilhe esses dados com ninguém. Editar incorretamente pode quebrar sua conta.",
   "go_back": "Voltar",

--- a/public/translations/ro/default.json
+++ b/public/translations/ro/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Pagina {{page}} (curentă)",
   "pagination.pageLabel": "Pagină",
   "archive": "Arhivă",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Căutați OPs...",
   "private_key_warning_title": "Avertisment cheie privată",
   "private_key_warning_description": "Acest editor afișează cheia privată a contului tău. Nu partaja aceste date cu nimeni. Editarea incorectă poate deteriora contul tău.",
   "go_back": "Înapoi",

--- a/public/translations/ru/default.json
+++ b/public/translations/ru/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Страница {{page}} (текущая)",
   "pagination.pageLabel": "Страница",
   "archive": "Архив",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Поиск OPs...",
   "private_key_warning_title": "Предупреждение о закрытом ключе",
   "private_key_warning_description": "Этот редактор показывает ваш приватный ключ. Не передавайте эти данные никому. Неправильное редактирование может повредить ваш аккаунт.",
   "go_back": "Назад",

--- a/public/translations/sq/default.json
+++ b/public/translations/sq/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Faqja {{page}} (aktuale)",
   "pagination.pageLabel": "Faqe",
   "archive": "Arkiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Kërko OPs...",
   "private_key_warning_title": "Paralajmërim për çelësin privat",
   "private_key_warning_description": "Ky redaktor tregon çelësin privat të llogarisë tuaj. Mos ndani këto të dhëna me askënd. Redaktimi gabim mund të dëmtojë llogarinë tuaj.",
   "go_back": "Kthehu",

--- a/public/translations/sv/default.json
+++ b/public/translations/sv/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Sida {{page}} (nuvarande)",
   "pagination.pageLabel": "Sida",
   "archive": "Arkiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Sök OPs...",
   "private_key_warning_title": "Varning för privat nyckel",
   "private_key_warning_description": "Denna redigerare visar ditt kontos privata nyckel. Del inte dessa data med någon. Felaktig redigering kan skada ditt konto.",
   "go_back": "Tillbaka",

--- a/public/translations/te/default.json
+++ b/public/translations/te/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "పేజీ {{page}} (ప్రస్తుత)",
   "pagination.pageLabel": "పేజీ",
   "archive": "ఆర్కైవ్",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPsను వెతకండి...",
   "private_key_warning_title": "ప్రైవేట్ కీ హెచ్చరిక",
   "private_key_warning_description": "ఈ ఎడిటర్ మీ ఖాతా యొక్క ప్రైవేట్ కీని చూపిస్తుంది. ఈ డేటాను ఎవరితోనూ భాగస్వామ్యం చేయవద్దు. తప్పుగా ఎడిట్ చేయడం మీ ఖాతాను పాడు చేయవచ్చు.",
   "go_back": "వెనుకకు",

--- a/public/translations/th/default.json
+++ b/public/translations/th/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "หน้า {{page}} (ปัจจุบัน)",
   "pagination.pageLabel": "หน้า",
   "archive": "เก็บถาวร",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "ค้นหา OPs...",
   "private_key_warning_title": "คำเตือนคีย์ส่วนตัว",
   "private_key_warning_description": "โปรแกรมแก้ไขนี้แสดงคีย์ส่วนตัวของบัญชีคุณ ห้ามแชร์ข้อมูลนี้กับใครก็ตาม การแก้ไขผิดพลาดอาจทำให้บัญชีของคุณเสียหายได้",
   "go_back": "กลับ",

--- a/public/translations/tr/default.json
+++ b/public/translations/tr/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Sayfa {{page}} (mevcut)",
   "pagination.pageLabel": "Sayfa",
   "archive": "Arşiv",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs ara...",
   "private_key_warning_title": "Özel anahtar uyarısı",
   "private_key_warning_description": "Bu düzenleyici hesabınızın özel anahtarını gösterir. Bu verileri kimseyle paylaşmayın. Yanlış düzenleme hesabınıza zarar verebilir.",
   "go_back": "Geri",

--- a/public/translations/uk/default.json
+++ b/public/translations/uk/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Сторінка {{page}} (поточна)",
   "pagination.pageLabel": "Сторінка",
   "archive": "Архів",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Пошук OPs...",
   "private_key_warning_title": "Попередження про приватний ключ",
   "private_key_warning_description": "Цей редактор показує приватний ключ вашого облікового запису. Не передавайте ці дані нікому. Неправильне редагування може пошкодити ваш обліковий запис.",
   "go_back": "Назад",

--- a/public/translations/ur/default.json
+++ b/public/translations/ur/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "صفحہ {{page}} (موجودہ)",
   "pagination.pageLabel": "صفحہ",
   "archive": "آرکائیو",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "OPs تلاش کریں...",
   "private_key_warning_title": "نجی کلید کی تنبیہ",
   "private_key_warning_description": "یہ ایڈیٹر آپ کے اکاؤنٹ کی نجی کلید دکھاتا ہے۔ یہ ڈیٹا کسی کے ساتھ شیئر نہ کریں۔ غلط ترمیم سے آپ کا اکاؤنٹ خراب ہو سکتا ہے۔",
   "go_back": "واپس جائیں",

--- a/public/translations/vi/default.json
+++ b/public/translations/vi/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "Trang {{page}} (hiện tại)",
   "pagination.pageLabel": "Trang",
   "archive": "Lưu trữ",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "Tìm kiếm OPs...",
   "private_key_warning_title": "Cảnh báo khóa riêng tư",
   "private_key_warning_description": "Trình chỉnh sửa này hiển thị khóa riêng tư của tài khoản bạn. Không chia sẻ dữ liệu này với bất kỳ ai. Chỉnh sửa sai có thể làm hỏng tài khoản của bạn.",
   "go_back": "Quay lại",

--- a/public/translations/zh/default.json
+++ b/public/translations/zh/default.json
@@ -284,7 +284,7 @@
   "pagination.pageCurrent": "第{{page}}页（当前）",
   "pagination.pageLabel": "页面",
   "archive": "归档",
-  "search_ops_placeholder": "Search OPs...",
+  "search_ops_placeholder": "搜索 OPs...",
   "private_key_warning_title": "私钥警告",
   "private_key_warning_description": "此编辑器显示您账户的私钥。请勿与任何人分享此数据。错误编辑可能会损坏您的账户。",
   "go_back": "返回",

--- a/src/components/challenge-modal/challenge-modal.tsx
+++ b/src/components/challenge-modal/challenge-modal.tsx
@@ -328,6 +328,24 @@ const Challenge = ({ challenge, closeModal }: ChallengeProps) => {
           />
         ) : (
           <>
+            <div className={styles.name}>
+              <input type='text' value={displayName || capitalize(t('anonymous'))} disabled />
+            </div>
+            {title && (
+              <div className={styles.subject}>
+                <input type='text' value={title} disabled />
+              </div>
+            )}
+            {content && (
+              <div className={styles.content}>
+                <textarea value={content} disabled cols={48} rows={4} wrap='soft' />
+              </div>
+            )}
+            {link && (
+              <div className={styles.link}>
+                <input type='text' value={link} disabled />
+              </div>
+            )}
             <div className={styles.challengeContainer}>
               <input
                 ref={inputRef}

--- a/src/components/comment-content/comment-content.tsx
+++ b/src/components/comment-content/comment-content.tsx
@@ -36,20 +36,26 @@ const useScopedCidToNumber = (cids: string[]) => {
     return [...uniqueCids].sort();
   }, [cids]);
 
-  const cidToNumber = usePostNumberStore((s) => s.cidToNumber);
+  const cidToNumber = usePostNumberStore(
+    useMemo(
+      () => (state) => {
+        if (sortedUniqueCids.length === 0) {
+          return {} as Record<string, number>;
+        }
+        const nextCidToNumber: Record<string, number> = {};
+        for (const cid of sortedUniqueCids) {
+          const number = state.cidToNumber[cid];
+          if (typeof number === 'number') {
+            nextCidToNumber[cid] = number;
+          }
+        }
+        return nextCidToNumber;
+      },
+      [sortedUniqueCids],
+    ),
+  );
 
-  if (sortedUniqueCids.length === 0) {
-    return {} as Record<string, number>;
-  }
-
-  const nextCidToNumber: Record<string, number> = {};
-  for (const cid of sortedUniqueCids) {
-    const number = cidToNumber[cid];
-    if (typeof number === 'number') {
-      nextCidToNumber[cid] = number;
-    }
-  }
-  return nextCidToNumber;
+  return cidToNumber;
 };
 
 const CommentContent = ({ comment: post }: { comment: Comment }) => {
@@ -80,23 +86,27 @@ const CommentContent = ({ comment: post }: { comment: Comment }) => {
   const isReply = !!parentCid;
   const isReplyingToReply = isReply && parentCid !== postCid;
 
-  const contentNumbers = !content ? new Set<number>() : new Set([...content.matchAll(/(?<![>/\w])>>(\d+)(?![\d/])/g)].map((m) => parseInt(m[1], 10)));
+  const contentNumbers = useMemo(() => {
+    if (!content) return new Set<number>();
+    return new Set([...content.matchAll(/(?<![>/\w])>>(\d+)(?![\d/])/g)].map((m) => parseInt(m[1], 10)));
+  }, [content]);
 
-  const relevantQuotedCids = (() => {
+  const relevantQuotedCids = useMemo(() => {
     const cids = quotedCids ? [...quotedCids] : [];
     if (parentCid) {
       cids.push(parentCid);
     }
     return cids;
-  })();
+  }, [quotedCids, parentCid]);
 
   const cidToNumber = useScopedCidToNumber(relevantQuotedCids);
-  const filteredQuotedCids = !quotedCids?.length
-    ? []
-    : quotedCids.filter((cid: string) => {
-        const num = cidToNumber[cid];
-        return num === undefined || !contentNumbers.has(num);
-      });
+  const filteredQuotedCids = useMemo(() => {
+    if (!quotedCids?.length) return [];
+    return quotedCids.filter((cid: string) => {
+      const num = cidToNumber[cid];
+      return num === undefined || !contentNumbers.has(num);
+    });
+  }, [quotedCids, cidToNumber, contentNumbers]);
 
   const shouldShowReplyingToReply = isReplyingToReply && (parentCid ? !contentNumbers.has(cidToNumber[parentCid] ?? -1) : true);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> UI changes are straightforward, but the refactor to store selection/memoization in `CommentContent` could subtly affect quote rendering if the selector dependencies or cid-to-number mapping are incorrect.
> 
> **Overview**
> **UI:** The challenge modal now displays the publication preview fields (name/subject/content/link) not only for iframe challenges but also for the standard text/image challenge flow.
> 
> **Performance/behavior:** `CommentContent` refactors quote-handling to use `useMemo` for derived sets/arrays and changes `useScopedCidToNumber` to select only the relevant `cidToNumber` entries from the store, reducing rerenders and avoiding work when no CIDs are referenced.
> 
> **i18n:** Updates `search_ops_placeholder` from English to localized strings across many `public/translations/*/default.json` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b8465a8eb46fc8e002006cecb941e2cf068f149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->