### PR TITLE
fix(settings-modal): raise settings modal above reply and challenge modals

### DIFF
--- a/src/components/settings-modal/settings-modal.module.css
+++ b/src/components/settings-modal/settings-modal.module.css
@@ -5,7 +5,7 @@
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.25);
-  z-index: 4;
+  z-index: 1001;
 }
 
 .settingsModal label, .settingsModal button, .settingsModal select {
@@ -39,7 +39,7 @@
   max-height: 80%;
   overflow-y: auto;
   position: fixed;
-  z-index: 5;
+  z-index: 1002;
   padding: 2px;
   font-size: var(--settings-modal-font-size);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Raise settings overlay and panel z-index (1001/1002) above reply and challenge modals (999) so the settings modal correctly intercepts clicks when open.

Closes #1061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change that adjusts stacking order for the settings overlay/dialog; low risk aside from potential unintended layering conflicts with other high z-index UI elements.
> 
> **Overview**
> Raises the `settings-modal` overlay and panel `z-index` to `1001/1002` so it renders above other modals (e.g., reply/challenge) and reliably intercepts clicks when open.
> 
> Also normalizes the CSS file ending (adds missing newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d044d3e60cfd2b9ea215720146c40e41dde59916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved modal component visual layering to ensure correct display hierarchy of interface elements.

* **Chores**
  * Applied minor file formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->