### PR TITLE
fix(viewport): remove maximum-scale=1 to restore reply modal autofocus on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="referrer" content="no-referrer" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="5chan is a free, open-source, decentralized imageboard built on the Bitsocial protocol. No servers, no admins — all content is shared peer-to-peer via IPFS." />
     <meta name="author" content="bitsocialnet" />


### PR DESCRIPTION
Removes `maximum-scale=1` from the viewport meta tag. iOS Safari blocks programmatic `focus()` on inputs when viewport scaling is restricted, which prevented the reply modal textarea from autofocusing on mobile.

Closes #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single static HTML meta tag change affecting mobile viewport/zoom behavior, with no backend or data/security impact.
> 
> **Overview**
> Removes `maximum-scale=1` from `index.html`’s viewport meta tag, allowing user zoom and avoiding mobile browser focus restrictions (e.g., enabling reply modal textarea autofocus on iOS Safari).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8105119ab5fdd001a2cd77184c4c76eff6420b83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled user zooming on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->