### PR TITLE
fix(edit-menu): allow pseudonymous reply deletion

### DIFF
--- a/src/components/edit-menu/__tests__/edit-menu.test.tsx
+++ b/src/components/edit-menu/__tests__/edit-menu.test.tsx
@@ -309,6 +309,21 @@ describe('EditMenu', () => {
     expect(testState.authorOptions).not.toHaveProperty('signer');
   });
 
+  it("does not allow delete-only access when pseudonymity mode is 'none'", async () => {
+    testState.pseudonymityMode = 'none';
+    testState.privileges = {
+      isAccountCommentAuthor: false,
+      isAccountMod: false,
+      isCommentAuthorMod: false,
+    };
+
+    await renderMenu(basePost);
+    await openMenu();
+
+    expect(alertSpy).toHaveBeenCalledWith('cannot_edit_thread');
+    expect(testState.publishAuthorEditMock).not.toHaveBeenCalled();
+  });
+
   it('lets moderators change moderation flags, ban duration, and save them', async () => {
     testState.privileges = {
       isAccountCommentAuthor: false,

--- a/src/components/edit-menu/edit-menu.tsx
+++ b/src/components/edit-menu/edit-menu.tsx
@@ -52,7 +52,8 @@ const EditMenu = ({ post }: { post: Comment }) => {
     postCid,
   });
   const pseudonymityMode = useBoardPseudonymityMode(communityAddress);
-  const canAttemptAuthorDelete = isAccountCommentAuthor || Boolean(pseudonymityMode);
+  const allowsPseudonymousDelete = pseudonymityMode !== undefined && pseudonymityMode !== 'none';
+  const canAttemptAuthorDelete = isAccountCommentAuthor || allowsPseudonymousDelete;
   const canOpenEditMenu = isAccountMod || canAttemptAuthorDelete;
   const requiresDeleteSelection = canAttemptAuthorDelete && !isAccountCommentAuthor && !isAccountMod;
   const signer = isAccountCommentAuthor ? account?.signer : undefined;

--- a/src/components/post-mobile/post-menu-mobile/__tests__/post-menu-mobile.test.tsx
+++ b/src/components/post-mobile/post-menu-mobile/__tests__/post-menu-mobile.test.tsx
@@ -211,6 +211,14 @@ describe('PostMenuMobile', () => {
     expect(document.body.querySelector('[data-testid="edit-menu"]')?.textContent).toBe('cid-1');
   });
 
+  it("does not show edit controls when pseudonymity mode is 'none' and the user lacks privileges", async () => {
+    testState.pseudonymityMode = 'none';
+
+    await renderMenu('/mu');
+
+    expect(document.body.querySelector('[data-testid="edit-menu"]')).toBeNull();
+  });
+
   it('omits thread hiding on the root thread route and suppresses the menu for deleted posts', async () => {
     await renderMenu('/mu/thread/cid-1');
     await openMenu();

--- a/src/components/post-mobile/post-menu-mobile/post-menu-mobile.tsx
+++ b/src/components/post-mobile/post-menu-mobile/post-menu-mobile.tsx
@@ -200,7 +200,7 @@ const PostMenuMobile = ({ postMenu, editMenuPost }: PostMenuMobileProps) => {
     subplebbitAddress: resolvedCommunityAddress || '',
   });
   const pseudonymityMode = useBoardPseudonymityMode(resolvedCommunityAddress);
-  const canAttemptAuthorDelete = Boolean(pseudonymityMode);
+  const canAttemptAuthorDelete = pseudonymityMode !== undefined && pseudonymityMode !== 'none';
   const commentMediaInfo = getCommentMediaInfo(link || '', thumbnailUrl || '', linkWidth || 0, linkHeight || 0);
   const { thumbnail, type, url } = commentMediaInfo || {};
   const [isMenuOpen, setIsMenuOpen] = useState(false);


### PR DESCRIPTION
Allow pseudonymous boards to offer a delete-only author flow even when the frontend cannot match the rendered author address, and avoid sending invalid author-edit payload overrides in that path. Adds regression coverage for the edit menu payload shape and the mobile entry point.

Closes #1075

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edit/delete permission gating and the author-edit payload shape; mistakes could unintentionally enable delete attempts or send malformed edit requests on some boards.
> 
> **Overview**
> Enables a **delete-only author flow** for boards with pseudonymity mode set (anything other than `none`), allowing users to open `EditMenu` and submit a deletion even when the UI can’t match the rendered author address.
> 
> Updates `EditMenu` to (1) gate opening/saving based on pseudonymity + privileges, (2) require the delete checkbox to be selected before enabling **Save** in the delete-only path, and (3) avoid including `author`/`signer` overrides in the publish payload unless the user is the verified comment author.
> 
> Updates `PostMenuMobile` to show edit controls when pseudonymity allows delete attempts, and adds regression tests for both desktop edit-menu behavior and the mobile entry point.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81367981bfc7b68d8e3edc8c10c9d4c3f655d29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit menu now accessible for pseudonymous (per-post) boards and other new permission scenarios.
  * Author-side deletion allowed in per-post pseudonymity mode without a local author-address match.
  * Delete confirmation checkbox must be checked before Save is enabled.

* **Tests**
  * Added tests covering pseudonymity/per-post behavior and edit-menu visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->