### PR TITLE
fix(testing): stabilize Vitest worktree runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "contract:imgur": "cd android && ./gradlew :app:connectedDebugAndroidTest -Pandroid.experimental.androidTest.useUnifiedTestPlatform=false -Pandroid.testInstrumentationRunnerArguments.class=fivechan.android.MediaUploadAutomationRunnerTest",
     "smoke:upload-selectors": "node scripts/smoke-upload-selectors.js",
     "test:coverage": "vitest run --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reportsDirectory=./coverage",
-    "test:coverage:changed": "vitest run --changed master --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reportsDirectory=./coverage --coverage.changed=master",
+    "test:coverage:changed": "vitest run --changed master --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reportsDirectory=./coverage",
     "retest:quality": "yarn test && yarn build && yarn lint && yarn type-check && yarn doctor",
     "blotter": "node scripts/update-blotter.js",
     "blotter:check": "node scripts/update-blotter.js check",


### PR DESCRIPTION
Stabilize Vitest runs across side worktrees by disabling Node web storage for the repo test scripts and document the repo-specific surprise for future agents.

Closes #1080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new `package.json` test scripts and does not change application/runtime code. Main impact is on CI/local testing behavior when these scripts are used.
> 
> **Overview**
> **Testing workflow update.** Adds `yarn test:leaks` to run Vitest with `--detectAsyncLeaks` and `yarn test:coverage:changed` to run coverage only for tests affected since `master` using `vitest run --changed`.
> 
> No production code or dependencies are modified; this PR is limited to `package.json` script additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ecbd4108e52d637703d2229ddf4886ba0ebdf38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new memory-leak detection test command to help catch async leaks during test runs.
  * Added a differential coverage command to produce coverage reports only for changed code versus the master branch.
  * Retained existing test and full-coverage commands; these additions augment test workflows and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->