### PR TITLE
fix(ci): publish coverage badge from badges branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,25 @@ jobs:
           fi
 
           git commit -m "chore(ci): update coverage badge"
-          git push origin "HEAD:${COVERAGE_BADGE_BRANCH}"
+
+          for attempt in 1 2 3; do
+            if git push --force-with-lease origin "HEAD:${COVERAGE_BADGE_BRANCH}"; then
+              exit 0
+            fi
+
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Failed to publish coverage badge after ${attempt} attempts."
+              exit 1
+            fi
+
+            echo "Push failed on attempt ${attempt}; syncing with origin/${COVERAGE_BADGE_BRANCH} before retrying..."
+            git fetch origin "${COVERAGE_BADGE_BRANCH}" || true
+            if git show-ref --verify --quiet "refs/remotes/origin/${COVERAGE_BADGE_BRANCH}"; then
+              git rebase "origin/${COVERAGE_BADGE_BRANCH}"
+            fi
+
+            sleep $((attempt * 2))
+          done
 
   android-build:
     name: Android Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/bitsocialnet/5chan/ci.yml?branch=master)](https://github.com/bitsocialnet/5chan/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bitsocialnet/5chan/refs/heads/badges/badges/coverage.json)](https://github.com/bitsocialnet/5chan/blob/master/scripts/write-coverage-badge.mjs)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bitsocialnet/5chan/badges/badges/coverage.json)](https://github.com/bitsocialnet/5chan/blob/master/scripts/write-coverage-badge.mjs)
 [![Release](https://img.shields.io/github/v/release/bitsocialnet/5chan)](https://github.com/bitsocialnet/5chan/releases/latest)
 [![License](https://img.shields.io/badge/license-GPL--2.0--only-red.svg)](https://github.com/bitsocialnet/5chan/blob/master/LICENSE)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)


### PR DESCRIPTION
## Summary
- stop trying to push generated coverage badge commits to protected `master`
- publish the badge JSON to a dedicated `badges` branch instead
- point the README badge at the `badges` branch and make the click target open the badge writer script

## Verification
- yarn build
- yarn lint
- yarn type-check
- local throwaway git simulation of first-run and no-op badge publishing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters how the coverage badge is published and referenced; main risk is the badge job failing to push/update the `badges` branch or the README URL being incorrect.
> 
> **Overview**
> Stops committing the generated coverage badge to protected `master` and instead publishes `badges/coverage.json` to a dedicated `badges` branch from the CI workflow (orphan-branch creation on first run, idempotent commit, and retrying push).
> 
> Updates the README coverage badge to fetch its endpoint JSON from the `badges` branch and changes the badge click target to the `scripts/write-coverage-badge.mjs` script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a2b52c0f76ab8c3023c7f318d3aceec443d3acd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved coverage badge publication with a more robust scripted workflow: explicit branch handling, commit checks, retry-on-fail pushes, and cleanup to ensure badges are published reliably.
* **Documentation**
  * Updated coverage badge links and endpoints in the README to point to the new badge location and its supporting script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->