### PR TITLE
fix(ci): scope Electron native rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
           ls -la build/index.html || exit 1
 
       - name: Rebuild and verify Electron native modules
+        timeout-minutes: 10
         run: yarn electron:prepare-package
 
       - name: Package Electron app
@@ -318,6 +319,7 @@ jobs:
           ls -la build/index.html || exit 1
 
       - name: Rebuild and verify Electron native modules
+        timeout-minutes: 10
         run: yarn electron:prepare-package
 
       - name: Package Electron app
@@ -383,6 +385,7 @@ jobs:
           ls -la build/index.html || exit 1
 
       - name: Rebuild and verify Electron native modules
+        timeout-minutes: 10
         run: yarn electron:prepare-package
 
       - name: Package Electron app
@@ -450,6 +453,7 @@ jobs:
 
       - name: Rebuild and verify Electron native modules
         shell: bash
+        timeout-minutes: 10
         run: yarn electron:prepare-package
 
       - name: Package Electron app

--- a/forge.config.js
+++ b/forge.config.js
@@ -46,7 +46,10 @@ const config = {
   },
 
   rebuildConfig: {
-    force: true,
+    // Only better-sqlite3 is intentionally prepared and verified before packaging.
+    // Using `onlyModules` prevents Forge from rebuilding unrelated optional addons
+    // that inflate Windows package times.
+    onlyModules: ['better-sqlite3'],
   },
 
   hooks: {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "electron:no-delete-data": "yarn build:preload && electron .",
     "electron:start": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://5chan.localhost:1355 && yarn electron\"",
     "electron:start:no-delete-data": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://5chan.localhost:1355 && yarn electron:no-delete-data\"",
-    "electron:rebuild-native": "electron-rebuild -f -w better-sqlite3",
+    "electron:rebuild-native": "electron-rebuild -f -o better-sqlite3",
     "electron:verify-native": "node scripts/verify-electron-native-modules.js",
     "electron:prepare-package": "yarn electron:rebuild-native && yarn electron:verify-native",
     "electron:package": "yarn build && yarn build:preload && yarn electron:prepare-package && electron-forge package",


### PR DESCRIPTION
Scope Electron native rebuilds to `better-sqlite3` so the Windows package job stops rebuilding unrelated addons, and fail the standalone native-module step fast if it regresses.

Closes #1098

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Electron packaging/rebuild behavior and could cause missing native addons if other modules actually require rebuilds. Limited blast radius to CI/package pipeline, not runtime app logic.
> 
> **Overview**
> **Electron packaging CI now fails faster and rebuilds less.** The `electron:prepare-package` step in `.github/workflows/ci.yml` has a 10-minute timeout across Linux/macOS/Windows packaging jobs to avoid long hangs/regressions.
> 
> **Native rebuilds are scoped to `better-sqlite3`.** `forge.config.js` restricts Forge’s `rebuildConfig` to `onlyModules: ['better-sqlite3']`, and `package.json` updates `electron:rebuild-native` to use `electron-rebuild -o better-sqlite3` so Windows packaging stops rebuilding unrelated optional addons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19da329fd630e70605ad9c6d70b02b8d2d474224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline reliability with improved timeout settings for native module compilation.
  * Optimized native module rebuild process to focus on critical dependencies, reducing unnecessary rebuilds.
  * Updated build script configuration for more precise native module handling during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->