### PR TITLE
fix(ci): publish coverage badge via GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,15 @@ jobs:
     needs: quality
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
-      contents: write
-    env:
-      COVERAGE_BADGE_BRANCH: badges
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
 
       - name: Download coverage badge
         uses: actions/download-artifact@v4
@@ -116,51 +118,23 @@ jobs:
           name: coverage-badge
           path: ${{ runner.temp }}/coverage-badge
 
-      - name: Publish coverage badge branch
+      - name: Prepare Pages artifact
         env:
           BADGE_SOURCE_PATH: ${{ runner.temp }}/coverage-badge/coverage.json
+          PAGES_OUTPUT_PATH: ${{ runner.temp }}/github-pages
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdir -p "${PAGES_OUTPUT_PATH}/badges"
+          cp "${BADGE_SOURCE_PATH}" "${PAGES_OUTPUT_PATH}/badges/coverage.json"
+          touch "${PAGES_OUTPUT_PATH}/.nojekyll"
 
-          if git ls-remote --exit-code --heads origin "${COVERAGE_BADGE_BRANCH}"; then
-            git fetch origin "${COVERAGE_BADGE_BRANCH}:${COVERAGE_BADGE_BRANCH}"
-            git switch "${COVERAGE_BADGE_BRANCH}"
-          else
-            git switch --orphan "${COVERAGE_BADGE_BRANCH}"
-            git rm -rf --ignore-unmatch .
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-          fi
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ${{ runner.temp }}/github-pages
 
-          mkdir -p badges
-          cp "${BADGE_SOURCE_PATH}" badges/coverage.json
-
-          git add badges/coverage.json
-          if git diff --cached --quiet; then
-            echo "Coverage badge is already up to date."
-            exit 0
-          fi
-
-          git commit -m "chore(ci): update coverage badge"
-
-          for attempt in 1 2 3; do
-            if git push --force-with-lease origin "HEAD:${COVERAGE_BADGE_BRANCH}"; then
-              exit 0
-            fi
-
-            if [ "${attempt}" -eq 3 ]; then
-              echo "Failed to publish coverage badge after ${attempt} attempts."
-              exit 1
-            fi
-
-            echo "Push failed on attempt ${attempt}; syncing with origin/${COVERAGE_BADGE_BRANCH} before retrying..."
-            git fetch origin "${COVERAGE_BADGE_BRANCH}" || true
-            if git show-ref --verify --quiet "refs/remotes/origin/${COVERAGE_BADGE_BRANCH}"; then
-              git rebase "origin/${COVERAGE_BADGE_BRANCH}"
-            fi
-
-            sleep $((attempt * 2))
-          done
+      - name: Deploy badge site
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   android-build:
     name: Android Build

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+/badges/
 *.lcov
 
 # nyc test coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/bitsocialnet/5chan/ci.yml?branch=master)](https://github.com/bitsocialnet/5chan/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bitsocialnet/5chan/badges/badges/coverage.json)](https://github.com/bitsocialnet/5chan/blob/master/scripts/write-coverage-badge.mjs)
+[![Coverage](https://img.shields.io/endpoint?url=https://bitsocialnet.github.io/5chan/badges/coverage.json)](https://github.com/bitsocialnet/5chan/blob/master/scripts/write-coverage-badge.mjs)
 [![Release](https://img.shields.io/github/v/release/bitsocialnet/5chan)](https://github.com/bitsocialnet/5chan/releases/latest)
 [![License](https://img.shields.io/badge/license-GPL--2.0--only-red.svg)](https://github.com/bitsocialnet/5chan/blob/master/LICENSE)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)

--- a/badges/coverage.json
+++ b/badges/coverage.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "coverage",
-  "message": "pending",
-  "color": "lightgrey"
-}


### PR DESCRIPTION
## Summary
- replace the branch-based coverage badge publish step with a GitHub Pages deployment
- point the README coverage badge at the Pages-hosted JSON endpoint
- stop tracking generated badge JSON in git so local coverage runs do not dirty the tree

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- yarn install --frozen-lockfile --ignore-engines --network-timeout 100000 --network-concurrency 1
- yarn test:coverage
- node scripts/write-coverage-badge.mjs
- yarn lint
- yarn type-check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI coverage badge publishing mechanism and GitHub permissions to use Pages/OIDC, which could break badge updates if Pages/environment settings are misconfigured. No production application code paths are affected.
> 
> **Overview**
> Switches coverage badge publishing from force-pushing a `badges` branch to deploying a small GitHub Pages artifact containing `badges/coverage.json` (with `.nojekyll`), updating the workflow to use `configure-pages`, `upload-pages-artifact`, and `deploy-pages` with Pages/OIDC permissions.
> 
> Updates the README badge endpoint to the new Pages URL, and stops tracking/generated `badges/` output in git by adding it to `.gitignore` and removing the committed `badges/coverage.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de723a076c2087848205422839fe3039fb8aefc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coverage badge URL in README.

* **Chores**
  * Refactored coverage badge deployment infrastructure.
  * Updated version control ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->