### PR TITLE
fix(ci): declare electron rebuild binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@electron-forge/maker-dmg": "7.8.0",
     "@electron-forge/maker-squirrel": "7.8.0",
     "@electron-forge/maker-zip": "7.8.0",
+    "@electron/rebuild": "3.7.2",
     "@reforged/maker-appimage": "5.1.1",
     "@types/lodash": "4.17.23",
     "@types/memoizee": "0.4.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,7 @@ __metadata:
     "@electron-forge/maker-dmg": "npm:7.8.0"
     "@electron-forge/maker-squirrel": "npm:7.8.0"
     "@electron-forge/maker-zip": "npm:7.8.0"
+    "@electron/rebuild": "npm:3.7.2"
     "@floating-ui/react": "npm:0.26.1"
     "@react-spring/web": "npm:9.7.5"
     "@reforged/maker-appimage": "npm:5.1.1"
@@ -2243,7 +2244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/rebuild@npm:^3.7.0":
+"@electron/rebuild@npm:3.7.2, @electron/rebuild@npm:^3.7.0":
   version: 3.7.2
   resolution: "@electron/rebuild@npm:3.7.2"
   dependencies:


### PR DESCRIPTION
## Summary\n- add @electron/rebuild as a direct dev dependency\n- restore the electron-rebuild binary expected by packaging scripts under Yarn 4\n- keep existing packaging workflow steps unchanged\n\n## Verification\n- yarn install\n- yarn build\n- yarn build:preload\n- yarn electron:prepare-package\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; it only affects install/packaging by ensuring the `electron-rebuild` binary is available under Yarn 4.
> 
> **Overview**
> Restores the `electron-rebuild` CLI availability in CI/packaging by adding `@electron/rebuild@3.7.2` as a direct `devDependency`.
> 
> Updates `yarn.lock` accordingly so existing Electron packaging scripts that call `electron-rebuild` continue to work under Yarn 4 without changing the workflow steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34662f19896149897218a61dfcc9000fae7a10c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->