### PR TITLE
perf(pwa): reduce precache asset fanout

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -33,7 +33,10 @@
     "stream-browserify",
     // The PWA service worker entry is injected by vite-plugin-pwa, which Knip does not trace here.
     "workbox-core",
-    "workbox-precaching"
+    "workbox-expiration",
+    "workbox-precaching",
+    "workbox-routing",
+    "workbox-strategies"
   ],
   "ignoreIssues": {
     // This import is intentionally satisfied transitively through bitsocial-react-hooks.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "tcp-port-used": "1.0.2",
     "typescript": "6.0.2",
     "workbox-core": "7.4.0",
+    "workbox-expiration": "7.4.0",
     "workbox-precaching": "7.4.0",
+    "workbox-routing": "7.4.0",
+    "workbox-strategies": "7.4.0",
     "zustand": "4.4.3"
   },
   "scripts": {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-restricted-globals */
 
 import { clientsClaim } from 'workbox-core';
+import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
 import { NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
@@ -29,6 +30,13 @@ registerRoute(
     (runtimeAssetDestinations.has(request.destination) || url.pathname.startsWith('/assets/') || url.pathname.startsWith('/translations/')),
   new StaleWhileRevalidate({
     cacheName: 'runtime-static-assets',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 200,
+        maxAgeSeconds: 60 * 60 * 24 * 30,
+        purgeOnQuotaError: true,
+      }),
+    ],
   }),
 );
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -11,13 +11,18 @@ declare const self: ServiceWorkerGlobalScope;
 
 const precacheEntries = self.__WB_MANIFEST.filter((entry) => (typeof entry === 'string' ? entry !== 'index.html' : entry.url !== 'index.html'));
 const runtimeAssetDestinations = new Set<RequestDestination>(['font', 'image', 'manifest', 'script', 'style']);
+const scopeRoot = self.registration.scope.endsWith('/') ? self.registration.scope : `${self.registration.scope}/`;
+const scopePath = (path: string) => new URL(path, scopeRoot).pathname;
+const apiPathPrefix = scopePath('api');
+const internalPathPrefix = scopePath('_(');
+const runtimeAssetPathPrefixes = ['assets/', 'translations/'].map(scopePath);
 
 // Precache revisioned assets, but let navigations fetch fresh HTML first.
 cleanupOutdatedCaches();
 precacheAndRoute(precacheEntries);
 
 registerRoute(
-  ({ request, url }) => request.mode === 'navigate' && !url.pathname.startsWith('/api') && !/^\/_\(.*\)/.test(url.pathname),
+  ({ request, url }) => request.mode === 'navigate' && !url.pathname.startsWith(apiPathPrefix) && !url.pathname.startsWith(internalPathPrefix),
   new NetworkFirst({
     cacheName: 'html-cache',
     networkTimeoutSeconds: 3,
@@ -27,7 +32,7 @@ registerRoute(
 registerRoute(
   ({ request, url }) =>
     url.origin === self.location.origin &&
-    (runtimeAssetDestinations.has(request.destination) || url.pathname.startsWith('/assets/') || url.pathname.startsWith('/translations/')),
+    (runtimeAssetDestinations.has(request.destination) || runtimeAssetPathPrefixes.some((prefix) => url.pathname.startsWith(prefix))),
   new StaleWhileRevalidate({
     cacheName: 'runtime-static-assets',
     plugins: [

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -4,11 +4,12 @@
 import { clientsClaim } from 'workbox-core';
 import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
-import { NetworkFirst } from 'workbox-strategies';
+import { NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
 
 declare const self: ServiceWorkerGlobalScope;
 
 const precacheEntries = self.__WB_MANIFEST.filter((entry) => (typeof entry === 'string' ? entry !== 'index.html' : entry.url !== 'index.html'));
+const runtimeAssetDestinations = new Set<RequestDestination>(['font', 'image', 'manifest', 'script', 'style']);
 
 // Precache revisioned assets, but let navigations fetch fresh HTML first.
 cleanupOutdatedCaches();
@@ -19,6 +20,15 @@ registerRoute(
   new NetworkFirst({
     cacheName: 'html-cache',
     networkTimeoutSeconds: 3,
+  }),
+);
+
+registerRoute(
+  ({ request, url }) =>
+    url.origin === self.location.origin &&
+    (runtimeAssetDestinations.has(request.destination) || url.pathname.startsWith('/assets/') || url.pathname.startsWith('/translations/')),
+  new StaleWhileRevalidate({
+    cacheName: 'runtime-static-assets',
   }),
 );
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -13,16 +13,18 @@ const precacheEntries = self.__WB_MANIFEST.filter((entry) => (typeof entry === '
 const runtimeAssetDestinations = new Set<RequestDestination>(['font', 'image', 'manifest', 'script', 'style']);
 const scopeRoot = self.registration.scope.endsWith('/') ? self.registration.scope : `${self.registration.scope}/`;
 const scopePath = (path: string) => new URL(path, scopeRoot).pathname;
-const apiPathPrefix = scopePath('api');
+const apiPath = scopePath('api');
+const apiPathPrefix = scopePath('api/');
 const internalPathPrefix = scopePath('_(');
 const runtimeAssetPathPrefixes = ['assets/', 'translations/'].map(scopePath);
+const isApiPath = (pathname: string) => pathname === apiPath || pathname.startsWith(apiPathPrefix);
 
 // Precache revisioned assets, but let navigations fetch fresh HTML first.
 cleanupOutdatedCaches();
 precacheAndRoute(precacheEntries);
 
 registerRoute(
-  ({ request, url }) => request.mode === 'navigate' && !url.pathname.startsWith(apiPathPrefix) && !url.pathname.startsWith(internalPathPrefix),
+  ({ request, url }) => request.mode === 'navigate' && !isApiPath(url.pathname) && !url.pathname.startsWith(internalPathPrefix),
   new NetworkFirst({
     cacheName: 'html-cache',
     networkTimeoutSeconds: 3,

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,15 @@ const basePathPrefix = (() => {
   return pathname === '/' ? '' : pathname.replace(/^\/+|\/+$/g, '');
 })();
 const neverPrecacheUrls = new Set(['index.html', 'version.json']);
-const vitePwaManagedAssetUrls = new Set(['manifest.webmanifest', 'favicon.ico', 'favicon2.ico', 'robots.txt', 'apple-touch-icon.png']);
+const vitePwaManagedAssetUrls = new Set([
+  'manifest.webmanifest',
+  'favicon.ico',
+  'favicon2.ico',
+  'robots.txt',
+  'apple-touch-icon.png',
+  'manifest-icon-192x192.png',
+  'manifest-icon-512x512.png',
+]);
 const baselineAppShellUrls = new Set([
   'registerSW.js',
   'manifest.json',
@@ -22,8 +30,8 @@ const baselineAppShellUrls = new Set([
   'favicon2.ico',
   'robots.txt',
   'apple-touch-icon.png',
-  'android-chrome-192x192.png',
-  'android-chrome-512x512.png',
+  'manifest-icon-192x192.png',
+  'manifest-icon-512x512.png',
 ]);
 
 function normalizePrecacheUrl(url) {
@@ -164,17 +172,17 @@ export default defineConfig({
         display: 'standalone',
         icons: [
           {
-            src: '/android-chrome-192x192.png',
+            src: 'manifest-icon-192x192.png',
             sizes: '192x192',
             type: 'image/png',
           },
           {
-            src: '/android-chrome-512x512.png',
+            src: 'manifest-icon-512x512.png',
             sizes: '512x512',
             type: 'image/png',
           },
           {
-            src: '/android-chrome-512x512.png',
+            src: 'manifest-icon-512x512.png',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'any maskable',

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,12 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 const appVersion = `${process.env.VITE_APP_VERSION || packageVersion}`.trim() || packageVersion;
+const publicBase = process.env.PUBLIC_URL || '/';
 const buildOutDir = 'build';
+const basePathPrefix = (() => {
+  const pathname = new URL(publicBase, 'https://example.invalid/').pathname;
+  return pathname === '/' ? '' : pathname.replace(/^\/+|\/+$/g, '');
+})();
 const neverPrecacheUrls = new Set(['index.html', 'version.json']);
 const vitePwaManagedAssetUrls = new Set(['manifest.webmanifest', 'favicon.ico', 'favicon2.ico', 'robots.txt', 'apple-touch-icon.png']);
 const baselineAppShellUrls = new Set([
@@ -22,7 +27,13 @@ const baselineAppShellUrls = new Set([
 ]);
 
 function normalizePrecacheUrl(url) {
-  return url.split('?')[0].replace(/^[./]+/, '');
+  const normalizedUrl = url.split('?')[0].replace(/^[./]+/, '');
+
+  if (basePathPrefix && normalizedUrl.startsWith(`${basePathPrefix}/`)) {
+    return normalizedUrl.slice(basePathPrefix.length + 1);
+  }
+
+  return normalizedUrl;
 }
 
 function collectIndexAssetUrls() {
@@ -298,7 +309,7 @@ export default defineConfig({
       },
     },
   },
-  base: process.env.PUBLIC_URL || '/',
+  base: publicBase,
   optimizeDeps: {
     include: ['ethers', 'assert', 'buffer', 'process', 'util', 'stream-browserify', 'isomorphic-fetch', 'workbox-core', 'workbox-precaching'],
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,55 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 const appVersion = `${process.env.VITE_APP_VERSION || packageVersion}`.trim() || packageVersion;
+const buildOutDir = 'build';
+const neverPrecacheUrls = new Set(['index.html', 'version.json']);
+const vitePwaManagedAssetUrls = new Set(['manifest.webmanifest', 'favicon.ico', 'favicon2.ico', 'robots.txt', 'apple-touch-icon.png']);
+const baselineAppShellUrls = new Set([
+  'registerSW.js',
+  'manifest.json',
+  'manifest.webmanifest',
+  'favicon.ico',
+  'favicon2.ico',
+  'robots.txt',
+  'apple-touch-icon.png',
+  'android-chrome-192x192.png',
+  'android-chrome-512x512.png',
+]);
+
+function normalizePrecacheUrl(url) {
+  return url.split('?')[0].replace(/^[./]+/, '');
+}
+
+function collectIndexAssetUrls() {
+  const indexHtml = readFileSync(new URL(`./${buildOutDir}/index.html`, import.meta.url), 'utf8');
+  const urls = new Set(baselineAppShellUrls);
+  const assetAttributePattern = /\b(?:href|src)=["'](?:\.\/|\/)?([^"']+\.(?:css|ico|js|json|png|webmanifest))(?:\?[^"']*)?["']/g;
+
+  for (const match of indexHtml.matchAll(assetAttributePattern)) {
+    urls.add(normalizePrecacheUrl(match[1]));
+  }
+
+  return urls;
+}
+
+function keepAppShellPrecacheOnly(manifestEntries) {
+  const appShellUrls = collectIndexAssetUrls();
+  const manifest = manifestEntries.filter((entry) => {
+    const normalizedUrl = normalizePrecacheUrl(entry.url);
+
+    if (neverPrecacheUrls.has(normalizedUrl)) {
+      return false;
+    }
+
+    if (vitePwaManagedAssetUrls.has(normalizedUrl)) {
+      return false;
+    }
+
+    return appShellUrls.has(normalizedUrl);
+  });
+
+  return { manifest };
+}
 
 function appVersionMetadataPlugin() {
   const payload = `${JSON.stringify({ version: appVersion })}\n`;
@@ -85,7 +134,8 @@ export default defineConfig({
       strategies: 'injectManifest',
       injectManifest: {
         maximumFileSizeToCacheInBytes: 20000000,
-        globIgnores: ['**/version.json'],
+        globPatterns: ['**/*.{css,html,ico,js,json,png,webmanifest}'],
+        manifestTransforms: [keepAppShellPrecacheOnly],
       },
       srcDir: 'src',
       filename: 'sw.ts',
@@ -216,7 +266,7 @@ export default defineConfig({
   },
   build: {
     // Use 'build' to match what electron/main.js expects (../build/index.html)
-    outDir: 'build',
+    outDir: buildOutDir,
     emptyOutDir: true,
     sourcemap: process.env.GENERATE_SOURCEMAP === 'true',
     target: process.env.ELECTRON ? 'electron-renderer' : 'esnext',

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,10 @@ __metadata:
     wait-on: "npm:9.0.3"
     workbox-build: "npm:7.4.0"
     workbox-core: "npm:7.4.0"
+    workbox-expiration: "npm:7.4.0"
     workbox-precaching: "npm:7.4.0"
+    workbox-routing: "npm:7.4.0"
+    workbox-strategies: "npm:7.4.0"
     workbox-window: "npm:7.4.0"
     zustand: "npm:4.4.3"
   dependenciesMeta:


### PR DESCRIPTION
## Summary
- scope Workbox precaching to the generated app shell instead of every build asset
- keep `index.html` and `version.json` out of the precache path so app updates stay fresh
- cache scripts, styles, fonts, images, manifests, and translations at runtime when users actually request them

## Impact
- generated precache drops to 27 unique entries
- estimated gzip transfer drops from about 4.03 MiB to about 1.40 MiB
- keeps installable PWA behavior and repeat-load caching while avoiding eager lazy-chunk caching

## Verification
- `corepack yarn build`
- `corepack yarn lint` passed with existing warnings only
- `corepack yarn type-check`
- `corepack yarn knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes service worker caching and precache generation, which can impact offline behavior, update rollout, and cache invalidation if URL matching is wrong or base paths differ across deployments.
> 
> **Overview**
> Reduces PWA precaching to *only the app shell* by filtering `injectManifest` entries based on URLs discovered in the built `index.html`, while explicitly keeping `index.html` and `version.json` out of precache so updates stay fresh.
> 
> Updates the service worker to add runtime `StaleWhileRevalidate` caching for same-origin static assets (scripts/styles/fonts/images/manifests plus `assets/` and `translations/`) with `ExpirationPlugin` limits, and refines navigation routing to be scope-aware (excluding `api` and internal `_(...)` paths). Also adds missing Workbox runtime packages (`workbox-expiration`, `workbox-routing`, `workbox-strategies`) and aligns PWA manifest icon paths to non-root-relative URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90bc804adbbd6c76cc9ce87db25dfbcb043fa6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added runtime caching for static assets (fonts, images, scripts, styles, translations) with automatic cache expiration (maximum 200 entries, 30-day lifespan)
  - Optimized PWA precaching strategy to selectively include app shell resources only

* **Chores**
  - Updated Workbox dependencies to v7.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->