### PR TITLE
chore(deps): bump bitsocial react hooks to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0-or-later",
   "private": true,
   "dependencies": {
-    "@bitsocial/bitsocial-react-hooks": "0.1.5",
+    "@bitsocial/bitsocial-react-hooks": "0.1.6",
     "@capacitor/app": "7.0.1",
     "@capacitor/status-bar": "7.0.1",
     "@capawesome/capacitor-android-edge-to-edge-support": "7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "5chan@workspace:."
   dependencies:
-    "@bitsocial/bitsocial-react-hooks": "npm:0.1.5"
+    "@bitsocial/bitsocial-react-hooks": "npm:0.1.6"
     "@capacitor/android": "npm:7.4.5"
     "@capacitor/app": "npm:7.0.1"
     "@capacitor/cli": "npm:7.4.5"
@@ -1522,12 +1522,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bitsocial-react-hooks@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.5"
+"@bitsocial/bitsocial-react-hooks@npm:0.1.6":
+  version: 0.1.6
+  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.6"
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.6"
-    "@pkcprotocol/pkc-js": "npm:0.0.23"
+    "@pkcprotocol/pkc-js": "npm:0.0.24"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     assert: "npm:2.0.0"
     ethers: "npm:5.8.0"
@@ -1538,12 +1538,12 @@ __metadata:
     peer-id: "npm:0.16.0"
     quick-lru: "npm:5.1.1"
     uint8arrays: "npm:3.1.1"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     viem: "npm:2.45.0"
     zustand: "npm:4.0.0"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/e8f1359dba264949d375fe27f5ec328b3ba0da3bafea8872bf930bf5d57fefada68c86ca1bdcdca2f84bce0a118775ed9bcb176de4f0c17f557cc532700acd64
+  checksum: 10c0/7c93c9430303ed60f32d2eff8601b700ea103f7d801e831967a8f7d34a4876f1087eeaf9bb0250ff36008a7276ad7146934713c3c5f52411faa46219e31576bd
   languageName: node
   linkType: hard
 
@@ -4006,6 +4006,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@libp2p/gossipsub@npm:15.0.21":
+  version: 15.0.21
+  resolution: "@libp2p/gossipsub@npm:15.0.21"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.17"
+    "@libp2p/interface": "npm:^3.2.2"
+    "@libp2p/interface-internal": "npm:^3.1.3"
+    "@libp2p/peer-id": "npm:^6.0.8"
+    "@libp2p/utils": "npm:^7.1.0"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    denque: "npm:^2.1.0"
+    it-length-prefixed: "npm:^10.0.1"
+    it-pipe: "npm:^3.0.1"
+    it-pushable: "npm:^3.2.3"
+    multiformats: "npm:^13.0.1"
+    protons-runtime: "npm:^6.0.1"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.0.1"
+  checksum: 10c0/d7001866a16020dd0a9cf49df0a798c97102851d991da21528dda91b190bb5e069151d08e36549d5c9ccdce481fe876adadd448121fcafb267049bc9ba5264d2
+  languageName: node
+  linkType: hard
+
 "@libp2p/http-fetch@npm:^4.0.0":
   version: 4.0.1
   resolution: "@libp2p/http-fetch@npm:4.0.1"
@@ -5794,6 +5816,66 @@ __metadata:
     uuid: "npm:13.0.0"
     zod: "npm:4.3.6"
   checksum: 10c0/c575983ca7d7fadff4f9058d700e0df210159ee086c4b44b31e68f1653f9c429766c12b440b1ab5d3b82dfe1a2807be1b6d7732379d64d5c6694a0f85f0b28f5
+  languageName: node
+  linkType: hard
+
+"@pkcprotocol/pkc-js@npm:0.0.24":
+  version: 0.0.24
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.24"
+  dependencies:
+    "@enhances/with-resolvers": "npm:0.0.5"
+    "@helia/block-brokers": "npm:5.2.4"
+    "@helia/delegated-routing-v1-http-api-client": "npm:6.0.1"
+    "@helia/ipns": "npm:9.2.1"
+    "@helia/unixfs": "npm:7.2.1"
+    "@libp2p/crypto": "npm:5.1.17"
+    "@libp2p/fetch": "npm:4.1.3"
+    "@libp2p/gossipsub": "npm:15.0.21"
+    "@libp2p/identify": "npm:4.1.3"
+    "@libp2p/interfaces": "npm:3.3.2"
+    "@libp2p/peer-id": "npm:6.0.8"
+    "@libp2p/websockets": "npm:10.1.11"
+    "@noble/curves": "npm:2.2.0"
+    "@pkcprotocol/pkc-logger": "npm:0.1.0"
+    "@pkcprotocol/proper-lock-file": "npm:4.2.1"
+    assert: "npm:2.1.0"
+    better-sqlite3: "npm:12.9.0"
+    blockstore-core: "npm:6.1.2"
+    blockstore-fs: "npm:3.0.2"
+    blockstore-idb: "npm:3.0.1"
+    buffer: "npm:6.0.3"
+    cbor: "npm:10.0.11"
+    debounce: "npm:1.2.1"
+    err-code: "npm:3.0.1"
+    ext-name: "npm:5.0.0"
+    helia: "npm:6.1.4"
+    hpagent: "npm:1.2.0"
+    it-all: "npm:3.0.6"
+    js-sha256: "npm:0.11.1"
+    js-sha512: "npm:0.9.0"
+    kubo-rpc-client: "npm:6.1.0"
+    limiter-es6-compat: "npm:2.1.2"
+    localforage: "npm:1.10.0"
+    lodash.merge: "npm:4.6.2"
+    lru-cache: "npm:10.1.0"
+    open-graph-scraper: "npm:6.11.0"
+    p-limit: "npm:7.3.0"
+    p-retry: "npm:8.0.0"
+    p-timeout: "npm:7.0.1"
+    probe-image-size: "npm:7.2.3"
+    remeda: "npm:1.57.0"
+    retry: "npm:0.13.1"
+    rpc-websockets: "npm:9.3.8"
+    safe-stable-stringify: "npm:2.4.3"
+    sha1-uint8array: "npm:0.10.7"
+    tcp-port-used: "npm:1.0.2"
+    tiny-typed-emitter: "npm:2.1.0"
+    tinycache: "npm:1.1.2"
+    ts-custom-error: "npm:3.3.1"
+    typestub-ipfs-only-hash: "npm:4.0.0"
+    uuid: "npm:13.0.0"
+    zod: "npm:4.3.6"
+  checksum: 10c0/8acff68a6ce5f1d545ce0a2f47e4a67eb9cc166d37fb9f13c8b3582b2124f984317b68a3ed4e8b7d386c19789f59a1acce8ac1284b40b18715b12a4ba488d7f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump @bitsocial/bitsocial-react-hooks from 0.1.5 to 0.1.6
- Refresh yarn.lock for the new hook package resolution

## Verification
- corepack yarn install
- corepack yarn knip
- corepack yarn lint (passes with existing warnings)
- corepack yarn type-check
- corepack yarn build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a dependency upgrade, but it pulls in updated transitive networking/crypto deps (notably `@pkcprotocol/pkc-js` and `uuid`) which could change runtime behavior in Bitsocial/PKC integration paths.
> 
> **Overview**
> Upgrades `@bitsocial/bitsocial-react-hooks` from `0.1.5` to `0.1.6`.
> 
> Refreshes `yarn.lock` to reflect the new dependency graph, including newer transitive versions like `@pkcprotocol/pkc-js@0.0.24`, `uuid@14`, and additional libp2p-related packages (e.g. `@libp2p/gossipsub`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ebd9ecc30a58a96723f9a71f6ed4beeef1b847b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to include latest library improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->