### PR TITLE
fix(mod queue): stop resurfacing stale pending history

### DIFF
--- a/src/lib/utils/__tests__/mod-queue-utils.test.ts
+++ b/src/lib/utils/__tests__/mod-queue-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { filterVisibleModQueueFeed, getModQueueCommentRoute, getQueuedCommentRouteState } from '../mod-queue-utils';
+import {
+  filterVisibleModQueueFeed,
+  getModQueueCommentRoute,
+  getQueuedCommentRouteState,
+  getVisibleQueuedCommentHistory,
+  shouldKeepQueuedCommentHistory,
+} from '../mod-queue-utils';
 
 describe('mod queue utils', () => {
   it('keeps all queue comments unless they were locally dismissed', () => {
@@ -28,6 +34,30 @@ describe('mod queue utils', () => {
 
     expect(filterVisibleModQueueFeed(feed, 'tech.eth', new Set(['tech-pending']))).toEqual([
       { cid: 'tech-approved', approved: true, communityAddress: 'tech.eth', pendingApproval: true },
+    ]);
+  });
+
+  it('keeps only terminal local moderation states in queue history', () => {
+    expect(shouldKeepQueuedCommentHistory({ cid: 'pending', pendingApproval: true })).toBe(false);
+    expect(shouldKeepQueuedCommentHistory({ cid: 'published', pendingApproval: false })).toBe(false);
+    expect(shouldKeepQueuedCommentHistory({ cid: 'approved', approved: true, pendingApproval: false })).toBe(true);
+    expect(shouldKeepQueuedCommentHistory({ cid: 'rejected', approved: false, pendingApproval: false })).toBe(true);
+    expect(shouldKeepQueuedCommentHistory({ cid: 'removed', pendingApproval: true, removed: true })).toBe(true);
+  });
+
+  it('does not resurface stale pending history after the live feed drops it', () => {
+    const feed = [{ cid: 'live-pending', communityAddress: 'tech.eth', pendingApproval: true }];
+    const history = [
+      { cid: 'stale-pending', communityAddress: 'tech.eth', pendingApproval: true },
+      { cid: 'live-pending', communityAddress: 'tech.eth', pendingApproval: true },
+      { cid: 'approved', approved: true, communityAddress: 'tech.eth', pendingApproval: false },
+      { cid: 'rejected', approved: false, communityAddress: 'tech.eth', pendingApproval: false },
+      { cid: 'other-board-approved', approved: true, communityAddress: 'g.eth', pendingApproval: false },
+    ];
+
+    expect(getVisibleQueuedCommentHistory(feed, history, ['tech.eth'])).toEqual([
+      { cid: 'approved', approved: true, communityAddress: 'tech.eth', pendingApproval: false },
+      { cid: 'rejected', approved: false, communityAddress: 'tech.eth', pendingApproval: false },
     ]);
   });
 

--- a/src/lib/utils/mod-queue-utils.ts
+++ b/src/lib/utils/mod-queue-utils.ts
@@ -1,5 +1,7 @@
 import type { Comment } from '@bitsocial/bitsocial-react-hooks';
 import { getCommentCommunityAddress } from './comment-utils';
+import { isPendingApprovalRejected } from './pending-approval-moderation';
+import { areSameBoardAddress } from './route-utils';
 import { getThreadTopNavigationState } from './thread-scroll-utils';
 
 type ModQueueCommentLike = {
@@ -100,6 +102,27 @@ export const getQueuedCommentRouteState = (comment: ModQueueCommentLike | undefi
     ...(queuedComment.parentCid ? {} : getThreadTopNavigationState(queuedComment.cid)),
     queuedComment,
   };
+};
+
+export const shouldKeepQueuedCommentHistory = (comment: ModQueueCommentLike | undefined): boolean => comment?.approved === true || isPendingApprovalRejected(comment);
+
+export const getVisibleQueuedCommentHistory = <T extends ModQueueCommentLike>(
+  feed: readonly ModQueueCommentLike[],
+  queuedCommentHistory: readonly T[],
+  communityAddresses: readonly string[],
+): T[] => {
+  const liveCids = feed.reduce<Set<string>>((cids, comment) => {
+    if (comment.cid) cids.add(comment.cid);
+    return cids;
+  }, new Set());
+
+  return queuedCommentHistory.filter((comment) => {
+    const commentCommunityAddress = getCommentCommunityAddress(comment);
+    if (!comment.cid || !shouldKeepQueuedCommentHistory(comment) || liveCids.has(comment.cid) || !commentCommunityAddress) {
+      return false;
+    }
+    return communityAddresses.some((communityAddress) => areSameBoardAddress(communityAddress, commentCommunityAddress));
+  });
 };
 
 export const filterVisibleModQueueFeed = <T extends ModQueueCommentLike>(

--- a/src/views/mod-queue/mod-queue.tsx
+++ b/src/views/mod-queue/mod-queue.tsx
@@ -26,7 +26,14 @@ import useChallengesStore from '../../stores/use-challenges-store';
 import { alertChallengeVerificationFailed } from '../../lib/utils/challenge-utils';
 import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
 import { formatErrorForDisplay } from '../../lib/utils/error-utils';
-import { filterVisibleModQueueFeed, getModQueueCommentRoute, getQueuedCommentRouteState, getQueuedCommentSnapshot } from '../../lib/utils/mod-queue-utils';
+import {
+  filterVisibleModQueueFeed,
+  getModQueueCommentRoute,
+  getQueuedCommentRouteState,
+  getQueuedCommentSnapshot,
+  getVisibleQueuedCommentHistory,
+  shouldKeepQueuedCommentHistory,
+} from '../../lib/utils/mod-queue-utils';
 import Tooltip from '../../components/tooltip';
 import { useAccountCommunityAddresses } from '../../hooks/use-account-community-addresses';
 import { useCommunityIdentifier, useCommunityIdentifiers } from '../../hooks/use-community-identifiers';
@@ -908,7 +915,7 @@ const ModQueueView = ({ boardIdentifier: propBoardIdentifier }: ModQueueViewProp
     () =>
       feed.flatMap((comment) => {
         const snapshot = getQueuedCommentSnapshot(comment);
-        return snapshot ? [snapshot] : [];
+        return snapshot && shouldKeepQueuedCommentHistory(snapshot) ? [snapshot] : [];
       }),
     [feed],
   );
@@ -918,24 +925,10 @@ const ModQueueView = ({ boardIdentifier: propBoardIdentifier }: ModQueueViewProp
     }
   }, [queuedCommentSnapshots, rememberCommentsInQueue]);
 
-  const feedWithHistory = useMemo(() => {
-    const liveCids = feed.reduce<Set<string>>((cids, comment) => {
-      if (comment.cid) cids.add(comment.cid);
-      return cids;
-    }, new Set());
-    return [
-      ...feed,
-      ...(queuedCommentHistory.filter((comment) => {
-        const commentCommunityAddress = getCommentCommunityAddress(comment);
-        return (
-          comment.cid &&
-          !liveCids.has(comment.cid) &&
-          commentCommunityAddress &&
-          communityAddresses.some((communityAddress) => areSameBoardAddress(communityAddress, commentCommunityAddress))
-        );
-      }) as Comment[]),
-    ];
-  }, [communityAddresses, feed, queuedCommentHistory]);
+  const feedWithHistory = useMemo(
+    () => [...feed, ...(getVisibleQueuedCommentHistory(feed, queuedCommentHistory, communityAddresses) as Comment[])],
+    [communityAddresses, feed, queuedCommentHistory],
+  );
 
   const dismissedCommentCidSet = useMemo(() => new Set(dismissedCommentCids), [dismissedCommentCids]);
   const filteredFeed = useMemo(


### PR DESCRIPTION
## Summary

- Stop storing live pending mod queue snapshots as persistent queue history.
- Only resurface historical queue items when they represent terminal local moderation state: approved, rejected, or removed.
- Add regression coverage for stale pending history that has disappeared from the live queue feed.

## Root cause

The mod queue persisted every queued item in `mod-queue-storage` and later merged that history back into the visible queue when the live feed no longer returned the item. On `5chan.app`, old pending snapshots from localStorage could therefore survive hard refreshes and reappear even after another moderator approved the posts.

## Verification

- `corepack yarn test src/lib/utils/__tests__/mod-queue-utils.test.ts`
- `corepack yarn lint`
- `corepack yarn type-check`
- `corepack yarn test`
- `corepack yarn doctor`
- `corepack yarn knip`
- `corepack yarn build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the moderation queue persists and rehydrates items, which can affect what moderators see and act on, but is limited to client-side filtering/presentation logic.
> 
> **Overview**
> Prevents the mod queue UI from re-adding *stale pending* items from persisted `queuedCommentHistory` once they’ve disappeared from the live feed.
> 
> This introduces `shouldKeepQueuedCommentHistory`/`getVisibleQueuedCommentHistory` to only persist and resurface **terminal** local moderation outcomes (approved/rejected/removed), and updates `ModQueueView` to use these helpers when snapshotting feed items and merging history back into the visible feed. Adds unit tests covering the terminal-state rule and the stale-pending regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b20e7fcadec85d9a3b43c158f29057ab25300d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced moderation queue history filtering to prevent stale pending items from reappearing once removed from the live feed
  * Updated queued comment history retention to only preserve terminal moderation states (approved, rejected, removed), automatically filtering out pending states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/5chan/pull/1130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->