### PR TITLE
fix(post-form): clear stale draft state on form remount

### DIFF
--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PostForm, { LinkTypePreviewer } from '../post-form';
 
@@ -30,6 +30,8 @@ const testState = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   offlineTitle: 'offline board',
   postIndex: undefined as number | undefined,
+  publishedPostOptions: undefined as Record<string, unknown> | undefined,
+  publishPostOptions: {} as Record<string, unknown>,
   publishPostMock: vi.fn(),
   publishReplyMock: vi.fn(),
   publishReplyError: null as string | null,
@@ -124,17 +126,49 @@ vi.mock('../../../hooks/use-publish-post', async () => {
 
   return {
     default: ({ communityAddress }: { communityAddress?: string }) => {
-      const [publishPostOptions, setPublishPostOptionsState] = React.useState<Record<string, unknown>>(communityAddress ? { communityAddress } : {});
+      const [, forceUpdate] = React.useReducer((value: number) => value + 1, 0);
+      const getPublishPostOptions = React.useCallback(
+        () => ({
+          ...(communityAddress ? { communityAddress } : {}),
+          ...testState.publishPostOptions,
+        }),
+        [communityAddress],
+      );
+      const publishPost = React.useCallback(() => {
+        testState.publishedPostOptions = getPublishPostOptions();
+        return testState.publishPostMock();
+      }, [getPublishPostOptions]);
+      const resetPublishPostOptions = React.useCallback(() => {
+        testState.publishPostOptions = {};
+        testState.resetPublishPostOptionsMock();
+        forceUpdate();
+      }, []);
+      const setPublishPostOptions = React.useCallback(
+        (options: Record<string, unknown>) => {
+          const sanitizedOptions = Object.entries(options).reduce(
+            (acc, [key, value]) => {
+              acc[key] = value === '' ? undefined : value;
+              return acc;
+            },
+            {} as Record<string, unknown>,
+          );
+
+          testState.setPublishPostOptionsMock(options);
+          testState.publishPostOptions = {
+            ...getPublishPostOptions(),
+            ...sanitizedOptions,
+          };
+          forceUpdate();
+        },
+        [getPublishPostOptions],
+      );
 
       return {
         postIndex: testState.postIndex,
-        publishPost: testState.publishPostMock,
-        publishPostOptions,
-        resetPublishPostOptions: testState.resetPublishPostOptionsMock,
-        setPublishPostOptions: (options: Record<string, unknown>) => {
-          testState.setPublishPostOptionsMock(options);
-          setPublishPostOptionsState((previous) => ({ ...previous, ...options }));
-        },
+        publishPost,
+        publishPostOptions: getPublishPostOptions(),
+        resetPublishPostOptions,
+        setPublishPostOptions,
       };
     },
   };
@@ -150,18 +184,21 @@ vi.mock('../../../hooks/use-publish-reply', async () => {
         postCid: postCid ?? cid,
         communityAddress,
       });
+      const publishReply = React.useCallback(() => testState.publishReplyMock(), []);
+      const resetPublishReplyOptions = React.useCallback(() => testState.resetPublishReplyOptionsMock(), []);
+      const setPublishReplyOptions = React.useCallback((options: Record<string, unknown>) => {
+        testState.setPublishReplyOptionsMock(options);
+        setPublishReplyOptionsState((previous) => ({ ...previous, ...options }));
+      }, []);
 
       return {
         isResolvingExternalQuotes: testState.isResolvingExternalQuotes,
-        publishReply: testState.publishReplyMock,
+        publishReply,
         publishReplyError: testState.publishReplyError,
         publishReplyStateMessage: testState.publishReplyStateMessage,
         replyIndex: testState.replyIndex,
-        resetPublishReplyOptions: testState.resetPublishReplyOptionsMock,
-        setPublishReplyOptions: (options: Record<string, unknown>) => {
-          testState.setPublishReplyOptionsMock(options);
-          setPublishReplyOptionsState((previous) => ({ ...previous, ...options }));
-        },
+        resetPublishReplyOptions,
+        setPublishReplyOptions,
         _publishReplyOptions: publishReplyOptions,
       };
     },
@@ -252,11 +289,42 @@ const renderPostForm = async (initialEntry: string) => {
   await flushEffects();
 };
 
+const KeyedPostForm = () => {
+  const location = useLocation();
+  return createElement(PostForm, { key: location.pathname });
+};
+
+const renderNavigablePostForm = async (initialEntry: string) => {
+  await act(async () => {
+    root.render(
+      createElement(
+        MemoryRouter,
+        { initialEntries: [initialEntry] },
+        createElement(
+          React.Fragment,
+          {},
+          createElement(Link, { to: '/biz' }, 'go_biz'),
+          createElement(Routes, {}, createElement(Route, { path: '/:boardIdentifier/*', element: createElement(KeyedPostForm) })),
+        ),
+      ),
+    );
+  });
+  await flushEffects();
+};
+
 const clickByText = async (scope: ParentNode, text: string, index = 0) => {
   const button = Array.from(scope.querySelectorAll('button')).filter((candidate) => candidate.textContent === text)[index] as HTMLButtonElement | undefined;
   await act(async () => {
     button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
+};
+
+const clickLinkByText = async (scope: ParentNode, text: string, index = 0) => {
+  const link = Array.from(scope.querySelectorAll('a')).filter((candidate) => candidate.textContent === text)[index] as HTMLAnchorElement | undefined;
+  await act(async () => {
+    link?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+  await flushEffects();
 };
 
 const dispatchInput = async (element: HTMLInputElement | HTMLTextAreaElement, value: string) => {
@@ -302,6 +370,8 @@ describe('PostForm', () => {
     testState.isResolvingExternalQuotes = false;
     testState.offlineTitle = 'offline board';
     testState.postIndex = undefined;
+    testState.publishedPostOptions = undefined;
+    testState.publishPostOptions = {};
     testState.publishReplyError = null;
     testState.publishReplyStateMessage = null;
     testState.replyIndex = undefined;
@@ -427,6 +497,40 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledTimes(1);
     expect(testState.setPublishPostOptionsMock).toHaveBeenCalledWith({ communityAddress: 'music-posting.eth' });
+  });
+
+  it('drops stale thread content when board navigation remounts the form before a link-only post', async () => {
+    await renderNavigablePostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    let table = container.querySelector('table');
+    let textarea = table?.querySelector('textarea');
+
+    expect(table).toBeTruthy();
+    expect(textarea).toBeTruthy();
+
+    await dispatchInput(textarea as HTMLTextAreaElement, 'stale draft body');
+    expect(testState.publishPostOptions.content).toBe('stale draft body');
+
+    await clickLinkByText(container, 'go_biz');
+    expect(testState.resetPublishPostOptionsMock).toHaveBeenCalledTimes(1);
+
+    await clickByText(container, 'start_new_thread');
+
+    table = container.querySelector('table');
+    textarea = table?.querySelector('textarea');
+    const textInputs = table?.querySelectorAll<HTMLInputElement>('input[type="text"]') || [];
+    const linkInput = textInputs[2];
+
+    expect(textarea?.value).toBe('');
+    expect(linkInput).toBeTruthy();
+
+    await dispatchInput(linkInput as HTMLInputElement, 'https://example.com/fresh.png');
+    await clickByText(table as HTMLTableElement, 'post');
+
+    expect(testState.publishPostMock).toHaveBeenCalledTimes(1);
+    expect(testState.publishedPostOptions?.link).toBe('https://example.com/fresh.png');
+    expect(testState.publishedPostOptions?.content).toBeUndefined();
   });
 
   it('shows the pasted file-link filename next to the upload button', async () => {

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -424,6 +424,17 @@ const PostFormTable = ({ closeForm, postCid }: { closeForm: () => void; postCid:
   const { isResolvingExternalQuotes, publishReply, publishReplyError, publishReplyStateMessage, resetPublishReplyOptions, replyIndex, setPublishReplyOptions } =
     usePublishReply({ cid, communityAddress, postCid });
 
+  useEffect(() => {
+    return () => {
+      checkContentLength.cancel();
+      if (isInPostView) {
+        resetPublishReplyOptions();
+      } else {
+        resetPublishPostOptions();
+      }
+    };
+  }, [checkContentLength, isInPostView, resetPublishPostOptions, resetPublishReplyOptions]);
+
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const content = e.target.value;
     if (isInPostView) {
@@ -467,11 +478,10 @@ const PostFormTable = ({ closeForm, postCid }: { closeForm: () => void; postCid:
 
   useEffect(() => {
     if (typeof replyIndex === 'number') {
-      resetPublishReplyOptions();
       resetFields();
       closeForm();
     }
-  }, [replyIndex, resetPublishReplyOptions, closeForm]);
+  }, [replyIndex, closeForm]);
 
   const { isUploading, uploadedFileName, handleUpload } = useFileUpload({
     onUploadComplete: (uploadedUrl: string) => {


### PR DESCRIPTION
## Summary
- reset post/reply publish store state when the visible post form unmounts
- add a regression test for stale thread content surviving board navigation and leaking into a link-only post

## Verification
- Red/green repro: applying only the regression test to pre-fix commit `4acd4449e` failed with `publishedPostOptions.content === "stale draft body"`; the same focused test passes on this branch
- `yarn test src/components/post-form/__tests__/post-form.test.tsx -t "drops stale thread content"`
- Previously run before commit: `yarn test`, `yarn lint`, `yarn type-check`, `yarn build`, `yarn doctor`
- Browser verification: Chrome/Firefox/WebKit desktop and mobile remount the form with an empty comment textarea; one Chrome desktop pending publish attempt on the provided test community showed only the new link and no stale draft body

## Notes
- Reviewed against `vercel:react-best-practices` and `you-might-not-need-an-effect`; the new cleanup effect ties the external publish store lifecycle to the already-keyed visible form lifecycle, rather than deriving render state or fetching data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PostForm lifecycle to clear publish-store state on unmount, which could affect users relying on draft persistence across navigation. Scope is localized to post/reply compose behavior with added test coverage.
> 
> **Overview**
> Prevents stale post/reply draft data from leaking across route changes by adding an unmount cleanup in `PostFormTable` that cancels the debounced length check and resets either post or reply publish options depending on view.
> 
> Adds a regression test that navigates between boards (forcing a keyed remount) and verifies a link-only post does not include prior thread `content`, plus updates the `use-publish-post`/`use-publish-reply` test mocks to better track and assert published options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20409b7ea50a900dfcf3756c05ab4e5661eb1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale draft content persisting when navigating between boards.
  * Improved form state cleanup and reset behavior when navigating away.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/5chan/pull/1131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->