### PR TITLE
fix(post form): align rules prompt test with bottom placement

### DIFF
--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -841,7 +841,7 @@ describe('PostForm', () => {
     expect(table?.textContent).toContain('file name.jpg');
   });
 
-  it('shows the rules and FAQ prompt below the file row with a board-specific rules link', async () => {
+  it('shows the rules and FAQ prompt at the bottom of the form with a board-specific rules link', async () => {
     testState.resolvedCommunityAddress = 'music-posting.eth';
 
     await renderPostForm('/mu');
@@ -855,7 +855,8 @@ describe('PostForm', () => {
     const links = Array.from(promptRow?.querySelectorAll('a') || []);
 
     expect(fileRowIndex).toBeGreaterThan(-1);
-    expect(promptRowIndex).toBe(fileRowIndex + 1);
+    expect(promptRowIndex).toBeGreaterThan(fileRowIndex);
+    expect(promptRowIndex).toBe(rows.length - 1);
     expect(promptRow?.className).toBe('rules');
     expect(promptRow?.querySelector('ul')?.className).toBe('rules');
     expect(links.map((link) => link.textContent)).toEqual(['Rules', 'FAQ']);


### PR DESCRIPTION
## Summary
- Updates the post form rules/FAQ prompt test to match the intentional bottom-of-form placement
- Keeps the existing board-specific Rules/FAQ link coverage

## Failing CI
- Fixes Vitest failure from https://github.com/bitsocialnet/5chan/actions/runs/26236088022

## Verification
- corepack yarn test src/components/post-form/__tests__/post-form.test.tsx -t "shows the rules and FAQ prompt at the bottom of the form with a board-specific rules link"
- corepack yarn test
- corepack yarn lint
- corepack yarn type-check
- corepack yarn build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a single Vitest assertion update and do not affect runtime code paths.
> 
> **Overview**
> Updates the `PostForm` test that verifies the Rules/FAQ prompt so it now asserts the prompt renders **at the bottom of the form** (last table row) rather than immediately after the file row, while keeping coverage for the board-specific `Rules` link (`/rules/:board`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ade2cc86805f5dd510be919fecfc193ca198be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated post form layout tests to reflect the repositioned rules and FAQ prompt, now appearing at the bottom of the form table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/5chan/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->