### PR TITLE
fix(flags): align board flag rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,12 @@ jobs:
           fi
 
       - name: Run React Doctor
-        if: github.event_name != 'pull_request' || steps.react-ui-changes.outputs.changed == 'true'
+        if: github.event_name != 'pull_request'
         run: yarn doctor
+
+      - name: Run React Doctor on changed React files
+        if: github.event_name == 'pull_request' && steps.react-ui-changes.outputs.changed == 'true'
+        run: yarn doctor --diff "${{ github.event.pull_request.base.sha }}" --annotations
 
       - name: Skip React Doctor
         if: github.event_name == 'pull_request' && steps.react-ui-changes.outputs.changed != 'true'

--- a/src/components/post-desktop/post-desktop.tsx
+++ b/src/components/post-desktop/post-desktop.tsx
@@ -70,6 +70,7 @@ import { getThreadPostCountsByAuthor } from '../../lib/utils/author-post-counts'
 import { withResolvedCommentCommunityAddress } from '../../lib/utils/comment-utils';
 import { getFeedPostHeightEstimate, getReplyHeightEstimates, reportReplyHeightAuditSample } from '../../lib/utils/pretext-height-estimates';
 import { getAuthorBadge } from '../../lib/utils/author-display-utils';
+import { hasCommentFlagsForDirectory } from '../../lib/comment-flag-selection';
 
 const { addChallenge } = useChallengesStore.getState();
 
@@ -242,7 +243,7 @@ const PostInfo = ({
   const directories = useDirectories();
   const directoryEntry = communityAddress ? findDirectoryByAddress(directories, communityAddress) : undefined;
   const boardPath = communityAddress ? getBoardPath(communityAddress, directories) : undefined;
-  const showAuthorFlags = directoryEntry?.features?.hasFlags === true && !(deleted || removed || purged);
+  const showAuthorFlags = hasCommentFlagsForDirectory(directoryEntry) && !(deleted || removed || purged);
   const postMenuProps = selectPostMenuProps(post);
 
   const params = useParams();

--- a/src/components/post-mobile/post-mobile.tsx
+++ b/src/components/post-mobile/post-mobile.tsx
@@ -59,6 +59,7 @@ import { getThreadPostCountsByAuthor } from '../../lib/utils/author-post-counts'
 import { withResolvedCommentCommunityAddress } from '../../lib/utils/comment-utils';
 import { getFeedPostHeightEstimate, getReplyHeightEstimates, reportReplyHeightAuditSample } from '../../lib/utils/pretext-height-estimates';
 import { getAuthorBadge } from '../../lib/utils/author-display-utils';
+import { hasCommentFlagsForDirectory } from '../../lib/comment-flag-selection';
 
 const { addChallenge } = useChallengesStore.getState();
 
@@ -89,7 +90,7 @@ const PostInfoAndMedia = ({
   const purged = resolvedPost?.commentModeration?.purged;
   const boardPath = communityAddress ? getBoardPath(communityAddress, directories) : undefined;
   const directoryEntry = communityAddress ? findDirectoryByAddress(directories, communityAddress) : undefined;
-  const showAuthorFlags = directoryEntry?.features?.hasFlags === true && !(deleted || removed || purged);
+  const showAuthorFlags = hasCommentFlagsForDirectory(directoryEntry) && !(deleted || removed || purged);
   const displayBoardPath =
     boardPath && communityAddress
       ? boardPath !== communityAddress

--- a/src/lib/__tests__/board-flags.test.ts
+++ b/src/lib/__tests__/board-flags.test.ts
@@ -19,6 +19,30 @@ describe('board-flags', () => {
       x: 0,
       y: 0,
     });
+    expect(getBoardFlagDefinition('pol', 'MZ')).toMatchObject({
+      code: 'MZ',
+      label: 'Task Force Z',
+      x: 64,
+      y: 24,
+    });
+    expect(getBoardFlagDefinition('pol', 'NB')).toMatchObject({
+      code: 'NB',
+      label: 'National Bolshevik',
+      x: 0,
+      y: 36,
+    });
+    expect(getBoardFlagDefinition('pol', 'RE')).toMatchObject({
+      code: 'RE',
+      label: 'Republican',
+      x: 0,
+      y: 48,
+    });
+    expect(getBoardFlagDefinition('pol', 'TM')).toMatchObject({
+      code: 'TM',
+      label: 'Templar',
+      x: 16,
+      y: 48,
+    });
     expect(getBoardFlagDefinition('pol', 'WP')).toMatchObject({ code: 'WP', x: 64, y: 48 });
   });
 

--- a/src/lib/__tests__/comment-flag-selection.test.ts
+++ b/src/lib/__tests__/comment-flag-selection.test.ts
@@ -4,11 +4,17 @@ import {
   getCommentFlagPublishOptionsForDirectory,
   getCommentFlagPublishOptionsFromSelection,
   getCommentFlagRequestFromSelection,
+  hasCommentFlagsForDirectory,
 } from '../comment-flag-selection';
 
 describe('comment-flag-selection', () => {
   it('does not expose options for boards without flags', () => {
     expect(getCommentFlagOptionsForDirectory({ features: {}, title: '/mu/ - Music' })).toEqual([]);
+  });
+
+  it('detects flag-capable directories from directory metadata', () => {
+    expect(hasCommentFlagsForDirectory({ features: {}, title: '/mu/ - Music' })).toBe(false);
+    expect(hasCommentFlagsForDirectory({ features: { hasFlags: true }, title: '/pol/ - Politically Incorrect' })).toBe(true);
   });
 
   it('uses geographic location as the default for country flag boards', () => {
@@ -58,6 +64,14 @@ describe('comment-flag-selection', () => {
       { label: 'Black Nationalist', value: 'pol:BL' },
       { label: 'Confederate', value: 'pol:CF' },
       { label: 'Communist', value: 'pol:CM' },
+    ]);
+    expect(options.slice(-6)).toEqual([
+      { label: 'Republican', value: 'pol:RE' },
+      { label: 'Task Force Z', value: 'pol:MZ' },
+      { label: 'Templar', value: 'pol:TM' },
+      { label: 'Tree Hugger', value: 'pol:TR' },
+      { label: 'United Nations', value: 'pol:UN' },
+      { label: 'White Supremacist', value: 'pol:WP' },
     ]);
   });
 

--- a/src/lib/board-flags.ts
+++ b/src/lib/board-flags.ts
@@ -21,6 +21,7 @@ const PONY_FLAG_HEIGHT = 16;
 const PONY_FLAG_COLUMNS = 9;
 const PONY_FLAG_SPRITE_PATH = 'assets/icons/flags-pony.png';
 
+// Order follows 4chan's board flag selector. Coordinates follow flags/pol/flags.2.css.
 const POLITICAL_FLAG_ENTRIES = [
   ['AC', 'Anarcho-Capitalist'],
   ['AN', 'Anarchist'],
@@ -42,12 +43,40 @@ const POLITICAL_FLAG_ENTRIES = [
   ['PC', 'Hippie'],
   ['PR', 'Pirate'],
   ['RE', 'Republican'],
-  ['TM', 'Templar'],
   ['MZ', 'Task Force Z'],
+  ['TM', 'Templar'],
   ['TR', 'Tree Hugger'],
   ['UN', 'United Nations'],
   ['WP', 'White Supremacist'],
 ] as const;
+
+const POLITICAL_FLAG_COORDINATES = {
+  AC: [0, 0],
+  AN: [16, 0],
+  BL: [32, 0],
+  CF: [48, 0],
+  CM: [64, 0],
+  CT: [0, 12],
+  DM: [16, 12],
+  EU: [32, 12],
+  FC: [48, 12],
+  GN: [64, 12],
+  GY: [0, 24],
+  JH: [16, 24],
+  KN: [32, 24],
+  MF: [48, 24],
+  MZ: [64, 24],
+  NB: [0, 36],
+  NT: [16, 36],
+  NZ: [32, 36],
+  PC: [48, 36],
+  PR: [64, 36],
+  RE: [0, 48],
+  TM: [16, 48],
+  TR: [32, 48],
+  UN: [48, 48],
+  WP: [64, 48],
+} as const satisfies Record<(typeof POLITICAL_FLAG_ENTRIES)[number][0], readonly [number, number]>;
 
 const PONY_FLAG_ENTRIES = [
   ['4CC', '4cc /mlp/'],
@@ -144,25 +173,37 @@ const buildFlagDefinitions = (
   width: number,
   height: number,
   columns: number,
+  coordinatesByCode?: Readonly<Record<string, readonly [number, number]>>,
 ): ReadonlyMap<string, BoardFlagDefinition> =>
   new Map(
-    entries.map(([code, label], index) => [
-      code,
-      {
-        kind,
+    entries.map(([code, label], index) => {
+      const [x, y] = coordinatesByCode?.[code] ?? [(index % columns) * width, Math.floor(index / columns) * height];
+      return [
         code,
-        label,
-        spritePath,
-        width,
-        height,
-        x: (index % columns) * width,
-        y: Math.floor(index / columns) * height,
-      },
-    ]),
+        {
+          kind,
+          code,
+          label,
+          spritePath,
+          width,
+          height,
+          x,
+          y,
+        },
+      ] as const;
+    }),
   );
 
 const BOARD_FLAGS_BY_KIND: Record<BoardFlagKind, ReadonlyMap<string, BoardFlagDefinition>> = {
-  pol: buildFlagDefinitions(POLITICAL_FLAG_ENTRIES, 'pol', POLITICAL_FLAG_SPRITE_PATH, POLITICAL_FLAG_WIDTH, POLITICAL_FLAG_HEIGHT, POLITICAL_FLAG_COLUMNS),
+  pol: buildFlagDefinitions(
+    POLITICAL_FLAG_ENTRIES,
+    'pol',
+    POLITICAL_FLAG_SPRITE_PATH,
+    POLITICAL_FLAG_WIDTH,
+    POLITICAL_FLAG_HEIGHT,
+    POLITICAL_FLAG_COLUMNS,
+    POLITICAL_FLAG_COORDINATES,
+  ),
   pony: buildFlagDefinitions(PONY_FLAG_ENTRIES, 'pony', PONY_FLAG_SPRITE_PATH, PONY_FLAG_WIDTH, PONY_FLAG_HEIGHT, PONY_FLAG_COLUMNS),
 };
 

--- a/src/lib/comment-flag-selection.ts
+++ b/src/lib/comment-flag-selection.ts
@@ -25,6 +25,8 @@ export interface CommentFlagPublishOptions {
   flairs: CommentFlagRequest[] | undefined;
 }
 
+export type CommentFlagDirectory = Partial<Pick<DirectoryCommunity, 'directoryCode' | 'features' | 'title'>>;
+
 const GEOGRAPHIC_LOCATION_OPTION: CommentFlagSelectOption = {
   value: GEOGRAPHIC_LOCATION_FLAG_VALUE,
   label: 'Geographic Location',
@@ -43,14 +45,18 @@ const getDirectoryCode = (directory: Pick<DirectoryCommunity, 'directoryCode' | 
   return directoryCode || directory?.title?.match(/^\/([^/]+)\//)?.[1]?.toLowerCase();
 };
 
+export const hasCommentFlagsForDirectory = (directory: CommentFlagDirectory | undefined): boolean => {
+  return directory?.features?.hasFlags === true;
+};
+
 const getBoardFlagOptions = (kind: BoardFlagKind): CommentFlagSelectOption[] =>
   getBoardFlagDefinitions(kind).map((flag) => ({
     value: `${flag.kind}:${flag.code}`,
     label: flag.label,
   }));
 
-export const getCommentFlagOptionsForDirectory = (directory: Pick<DirectoryCommunity, 'directoryCode' | 'features' | 'title'> | undefined): CommentFlagSelectOption[] => {
-  if (directory?.features?.hasFlags !== true) {
+export const getCommentFlagOptionsForDirectory = (directory: CommentFlagDirectory | undefined): CommentFlagSelectOption[] => {
+  if (!hasCommentFlagsForDirectory(directory)) {
     return [];
   }
 
@@ -70,11 +76,8 @@ export const getCommentFlagOptionsForDirectory = (directory: Pick<DirectoryCommu
   return [GEOGRAPHIC_LOCATION_OPTION];
 };
 
-export const getCommentFlagPublishOptionsForDirectory = (
-  directory: Pick<DirectoryCommunity, 'directoryCode' | 'features' | 'title'> | undefined,
-  selectedValue?: string,
-): CommentFlagPublishOptions => {
-  if (directory?.features?.hasFlags !== true) {
+export const getCommentFlagPublishOptionsForDirectory = (directory: CommentFlagDirectory | undefined, selectedValue?: string): CommentFlagPublishOptions => {
+  if (!hasCommentFlagsForDirectory(directory)) {
     return {
       challengeRequest: undefined,
       flairs: undefined,


### PR DESCRIPTION
## Summary
- remove the temporary test-community flag fallback so flags depend on directory metadata
- share the hasFlags check between flag publishing and post rendering
- align /pol/ board flag selector order and sprite coordinates with 4chan sources

## Verification
- corepack yarn test
- corepack yarn type-check
- corepack yarn lint
- corepack yarn build
- corepack yarn doctor
- focused post-rebase: corepack yarn test --run src/lib/__tests__/board-flags.test.ts src/lib/__tests__/comment-flag-selection.test.ts src/lib/__tests__/comment-flags.test.ts src/components/post-form/__tests__/post-form.test.tsx src/components/reply-modal/__tests__/reply-modal.test.tsx
- browser checks in Chrome, Firefox, and WebKit confirmed the temporary test address no longer gets flags while /pol/, /mlp/, and /bant/ behavior remains correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and flag-metadata alignment with expanded tests; no auth or data-path changes. CI behavior for React Doctor on PRs is narrower in scope.
> 
> **Overview**
> **Board flags** now use a shared `hasCommentFlagsForDirectory` check so post rendering and flag publish/selector logic agree on when flags apply. Desktop and mobile posts use that helper for author flag display instead of duplicating `features.hasFlags`.
> 
> **/pol/** political flags match 4chan selector **order** and **sprite positions** via explicit coordinates (not index-based grid math), with tests covering key codes and `/pol/` option ordering.
> 
> **CI** runs full `yarn doctor` only on non-PR builds; on PRs with React UI changes it runs `yarn doctor --diff` with annotations on the changed files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b5bafa97397ba1c8443f14ee09dd975c4e4ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Author flags display now consistently respects directory flag capability (hidden for deleted/removed/purged posts).
  * Political flags use updated sprite positions for improved visual alignment.

* **Tests**
  * Expanded tests for political flag definitions and comment-flag directory detection/selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/5chan/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->