### PR TITLE
fix: embed additional direct image formats

### DIFF
--- a/src/lib/media-hosting/__tests__/direct-url.test.ts
+++ b/src/lib/media-hosting/__tests__/direct-url.test.ts
@@ -7,9 +7,14 @@ describe('direct-url', () => {
       expect(isDirectMediaUrl('https://example.com/photo.jpg')).toBe(true);
       expect(isDirectMediaUrl('https://i.ibb.co/example/photo.jpg')).toBe(true);
       expect(isDirectMediaUrl('https://example.com/photo.jpeg')).toBe(true);
+      expect(isDirectMediaUrl('https://example.com/photo.jpe')).toBe(true);
+      expect(isDirectMediaUrl('https://example.com/photo.jfif')).toBe(true);
+      expect(isDirectMediaUrl('https://example.com/photo.jif')).toBe(true);
       expect(isDirectMediaUrl('https://example.com/photo.png')).toBe(true);
+      expect(isDirectMediaUrl('https://example.com/photo.apng')).toBe(true);
       expect(isDirectMediaUrl('https://example.com/photo.gif')).toBe(true);
       expect(isDirectMediaUrl('https://example.com/photo.webp')).toBe(true);
+      expect(isDirectMediaUrl('https://example.com/photo.avif')).toBe(true);
     });
 
     it('returns true for video extensions', () => {

--- a/src/lib/media-hosting/direct-url.ts
+++ b/src/lib/media-hosting/direct-url.ts
@@ -1,5 +1,23 @@
 /** File extensions that denote direct media URLs (images, videos, and Flash movies) */
-const DIRECT_MEDIA_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.webm', '.mp4', '.mov', '.avi', '.mkv', '.gifv', '.swf'] as const;
+const DIRECT_MEDIA_EXTENSIONS = [
+  '.jpg',
+  '.jpeg',
+  '.jpe',
+  '.jfif',
+  '.jif',
+  '.png',
+  '.apng',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.webm',
+  '.mp4',
+  '.mov',
+  '.avi',
+  '.mkv',
+  '.gifv',
+  '.swf',
+] as const;
 
 /** Returns true if the URL appears to point to a direct media file */
 export function isDirectMediaUrl(url: string): boolean {

--- a/src/lib/utils/__tests__/media-utils.test.ts
+++ b/src/lib/utils/__tests__/media-utils.test.ts
@@ -131,7 +131,12 @@ describe('media-utils', () => {
     });
     expect(getLinkMediaInfo('https://example.com/file.gif')).toMatchObject({ type: 'gif' });
     expect(getLinkMediaInfo('https://external-preview.redd.it/example.gif?width=480&format=mp4')).toMatchObject({ type: 'video' });
+    expect(getLinkMediaInfo('https://example.com/file.jfif')).toMatchObject({ type: 'image' });
+    expect(getLinkMediaInfo('https://example.com/file.jpe')).toMatchObject({ type: 'image' });
+    expect(getLinkMediaInfo('https://example.com/file.jif')).toMatchObject({ type: 'image' });
     expect(getLinkMediaInfo('https://example.com/file.png')).toMatchObject({ type: 'image' });
+    expect(getLinkMediaInfo('https://example.com/file.apng')).toMatchObject({ type: 'image' });
+    expect(getLinkMediaInfo('https://example.com/file.avif')).toMatchObject({ type: 'image' });
     expect(getLinkMediaInfo('https://example.com/file.mp4')).toMatchObject({ type: 'video' });
     expect(getLinkMediaInfo('https://example.com/file.mp3')).toMatchObject({ type: 'audio' });
     expect(getLinkMediaInfo('https://example.com/file.swf')).toMatchObject({ type: 'swf' });

--- a/src/lib/utils/media-utils.ts
+++ b/src/lib/utils/media-utils.ts
@@ -78,7 +78,7 @@ const getPatternThumbnailUrl = (url: URL): string | undefined => {
 };
 
 // Known media file extensions - only these will be classified as media files
-const KNOWN_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'ico', 'tiff'];
+const KNOWN_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'jpe', 'jfif', 'jif', 'png', 'apng', 'gif', 'webp', 'avif', 'svg', 'bmp', 'ico', 'tiff'];
 const KNOWN_VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi', 'mkv', 'flv', 'wmv', 'm4v'];
 const KNOWN_AUDIO_EXTENSIONS = ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a', 'wma'];
 const KNOWN_SWF_EXTENSIONS = ['swf'];


### PR DESCRIPTION
## Summary
- classify direct `.avif`, `.apng`, `.jpe`, `.jfif`, and `.jif` links as image media
- keep media-hosting direct URL detection aligned with comment media detection
- add tests for the newly recognized direct image extensions

## Root Cause
5chan only embeds direct media links when their file extension is in an explicit allowlist. AVIF, APNG, and common JPEG filename aliases were missing from that allowlist, so those links fell back to webpage handling.

## Verification
- `corepack yarn test src/lib/utils/__tests__/media-utils.test.ts src/lib/media-hosting/__tests__/direct-url.test.ts --run`
- `corepack yarn test --run`
- `corepack yarn lint`
- `corepack yarn type-check`
- `corepack yarn build`
- `git diff --check`
- `playwright-cli` checks in Chrome, Firefox, and WebKit confirming `.avif`, `.apng`, `.jpe`, `.jfif`, and `.jif` return `linkType: "image"` and `direct: true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Allowlist-only changes to media URL classification with matching unit tests; no auth, data, or security-sensitive logic.
> 
> **Overview**
> Extends the direct-image allowlists so links ending in **`.avif`**, **`.apng`**, and JPEG aliases **`.jpe`**, **`.jfif`**, and **`.jif`** embed as images instead of generic webpages.
> 
> **`isDirectMediaUrl`** in `direct-url.ts` and **`KNOWN_IMAGE_EXTENSIONS`** in `media-utils.ts` are updated together so media-hosting direct-URL checks match comment/link classification. Tests cover the new extensions in both modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48470a617471ee42b738c3d29d977b4ddcbfd858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended image format support to recognize and properly handle additional image file types (.jpe, .jfif, .jif, .apng, and .avif) for improved media compatibility across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/5chan/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->