### PR TITLE
fix(embed): restore youtube thumbnails and file-row labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build:fdroid": "cross-env PUBLIC_URL=./ GENERATE_SOURCEMAP=false VITE_APP_DISTRIBUTION=fdroid vite build",
     "build:preload": "vite build --config electron/vite.preload.config.js",
     "build-vercel": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" PUBLIC_URL=./ GENERATE_SOURCEMAP=true VITE_COMMIT_REF=$COMMIT_REF CI='' vite build",
-    "test": "vitest",
+    "test": "vitest --maxWorkers=4",
     "test:leaks": "vitest run --detectAsyncLeaks",
     "preview": "vite preview",
     "analyze-bundle": "cross-env PUBLIC_URL=./ GENERATE_SOURCEMAP=true vite build && npx source-map-explorer 'dist/assets/*.js'",

--- a/public/translations/ar/default.json
+++ b/public/translations/ar/default.json
@@ -399,5 +399,6 @@
   "ban": "حظر",
   "timestamp": "الطابع الزمني",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ar/default.json
+++ b/public/translations/ar/default.json
@@ -400,5 +400,5 @@
   "timestamp": "الطابع الزمني",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "فيديو YouTube"
 }

--- a/public/translations/bn/default.json
+++ b/public/translations/bn/default.json
@@ -400,5 +400,5 @@
   "timestamp": "টাইমস্ট্যাম্প",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube ভিডিও"
 }

--- a/public/translations/bn/default.json
+++ b/public/translations/bn/default.json
@@ -399,5 +399,6 @@
   "ban": "নিষেধ করুন",
   "timestamp": "টাইমস্ট্যাম্প",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/cs/default.json
+++ b/public/translations/cs/default.json
@@ -400,5 +400,5 @@
   "timestamp": "časové razítko",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/cs/default.json
+++ b/public/translations/cs/default.json
@@ -399,5 +399,6 @@
   "ban": "zakázat",
   "timestamp": "časové razítko",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/da/default.json
+++ b/public/translations/da/default.json
@@ -399,5 +399,6 @@
   "ban": "forbyd",
   "timestamp": "tidsstempel",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/da/default.json
+++ b/public/translations/da/default.json
@@ -400,5 +400,5 @@
   "timestamp": "tidsstempel",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-video"
 }

--- a/public/translations/de/default.json
+++ b/public/translations/de/default.json
@@ -400,5 +400,5 @@
   "timestamp": "Zeitstempel",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-Video"
 }

--- a/public/translations/de/default.json
+++ b/public/translations/de/default.json
@@ -399,5 +399,6 @@
   "ban": "sperren",
   "timestamp": "Zeitstempel",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/el/default.json
+++ b/public/translations/el/default.json
@@ -399,5 +399,6 @@
   "ban": "απαγόρευση",
   "timestamp": "χρονοσήμανση",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/el/default.json
+++ b/public/translations/el/default.json
@@ -400,5 +400,5 @@
   "timestamp": "χρονοσήμανση",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "βίντεο YouTube"
 }

--- a/public/translations/en/default.json
+++ b/public/translations/en/default.json
@@ -419,5 +419,5 @@
   "timestamp": "timestamp",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube video"
 }

--- a/public/translations/en/default.json
+++ b/public/translations/en/default.json
@@ -418,5 +418,6 @@
   "ban": "ban",
   "timestamp": "timestamp",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/es/default.json
+++ b/public/translations/es/default.json
@@ -400,5 +400,5 @@
   "timestamp": "marca de tiempo",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video de YouTube"
 }

--- a/public/translations/es/default.json
+++ b/public/translations/es/default.json
@@ -399,5 +399,6 @@
   "ban": "prohibir",
   "timestamp": "marca de tiempo",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/fa/default.json
+++ b/public/translations/fa/default.json
@@ -400,5 +400,5 @@
   "timestamp": "مهر زمان",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "ویدیوی YouTube"
 }

--- a/public/translations/fa/default.json
+++ b/public/translations/fa/default.json
@@ -399,5 +399,6 @@
   "ban": "مسدود کردن",
   "timestamp": "مهر زمان",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/fi/default.json
+++ b/public/translations/fi/default.json
@@ -400,5 +400,5 @@
   "timestamp": "aikaleimaustiedosto",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-video"
 }

--- a/public/translations/fi/default.json
+++ b/public/translations/fi/default.json
@@ -399,5 +399,6 @@
   "ban": "kielto",
   "timestamp": "aikaleimaustiedosto",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/fil/default.json
+++ b/public/translations/fil/default.json
@@ -399,5 +399,6 @@
   "ban": "ipagbawal",
   "timestamp": "timestamp",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/fil/default.json
+++ b/public/translations/fil/default.json
@@ -400,5 +400,5 @@
   "timestamp": "timestamp",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video sa YouTube"
 }

--- a/public/translations/fr/default.json
+++ b/public/translations/fr/default.json
@@ -399,5 +399,6 @@
   "ban": "interdire",
   "timestamp": "horodatage",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/fr/default.json
+++ b/public/translations/fr/default.json
@@ -400,5 +400,5 @@
   "timestamp": "horodatage",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "vidéo YouTube"
 }

--- a/public/translations/he/default.json
+++ b/public/translations/he/default.json
@@ -400,5 +400,5 @@
   "timestamp": "חותמת זמן",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "סרטון YouTube"
 }

--- a/public/translations/he/default.json
+++ b/public/translations/he/default.json
@@ -399,5 +399,6 @@
   "ban": "חסימה",
   "timestamp": "חותמת זמן",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/hi/default.json
+++ b/public/translations/hi/default.json
@@ -399,5 +399,6 @@
   "ban": "प्रतिबंध",
   "timestamp": "टाइमस्टैंप",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/hi/default.json
+++ b/public/translations/hi/default.json
@@ -400,5 +400,5 @@
   "timestamp": "टाइमस्टैंप",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube वीडियो"
 }

--- a/public/translations/hu/default.json
+++ b/public/translations/hu/default.json
@@ -399,5 +399,6 @@
   "ban": "tiltás",
   "timestamp": "időbélyeg",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/hu/default.json
+++ b/public/translations/hu/default.json
@@ -400,5 +400,5 @@
   "timestamp": "időbélyeg",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-videó"
 }

--- a/public/translations/id/default.json
+++ b/public/translations/id/default.json
@@ -399,5 +399,6 @@
   "ban": "larangan",
   "timestamp": "stempel waktu",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/id/default.json
+++ b/public/translations/id/default.json
@@ -400,5 +400,5 @@
   "timestamp": "stempel waktu",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/it/default.json
+++ b/public/translations/it/default.json
@@ -400,5 +400,5 @@
   "timestamp": "marca temporale",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/it/default.json
+++ b/public/translations/it/default.json
@@ -399,5 +399,6 @@
   "ban": "vietare",
   "timestamp": "marca temporale",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ja/default.json
+++ b/public/translations/ja/default.json
@@ -399,5 +399,6 @@
   "ban": "ブロック",
   "timestamp": "タイムスタンプ",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ja/default.json
+++ b/public/translations/ja/default.json
@@ -400,5 +400,5 @@
   "timestamp": "タイムスタンプ",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube動画"
 }

--- a/public/translations/ko/default.json
+++ b/public/translations/ko/default.json
@@ -399,5 +399,6 @@
   "ban": "차단",
   "timestamp": "타임스탬프",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ko/default.json
+++ b/public/translations/ko/default.json
@@ -400,5 +400,5 @@
   "timestamp": "타임스탬프",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube 동영상"
 }

--- a/public/translations/mr/default.json
+++ b/public/translations/mr/default.json
@@ -399,5 +399,6 @@
   "ban": "प्रतिबंध",
   "timestamp": "टाइमस्टॅम्प",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/mr/default.json
+++ b/public/translations/mr/default.json
@@ -400,5 +400,5 @@
   "timestamp": "टाइमस्टॅम्प",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube व्हिडिओ"
 }

--- a/public/translations/nl/default.json
+++ b/public/translations/nl/default.json
@@ -400,5 +400,5 @@
   "timestamp": "tijdstempel",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-video"
 }

--- a/public/translations/nl/default.json
+++ b/public/translations/nl/default.json
@@ -399,5 +399,6 @@
   "ban": "verbannen",
   "timestamp": "tijdstempel",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/no/default.json
+++ b/public/translations/no/default.json
@@ -399,5 +399,6 @@
   "ban": "forbud",
   "timestamp": "tidsstempel",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/no/default.json
+++ b/public/translations/no/default.json
@@ -400,5 +400,5 @@
   "timestamp": "tidsstempel",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-video"
 }

--- a/public/translations/pl/default.json
+++ b/public/translations/pl/default.json
@@ -400,5 +400,5 @@
   "timestamp": "znacznik czasu",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "wideo YouTube"
 }

--- a/public/translations/pl/default.json
+++ b/public/translations/pl/default.json
@@ -399,5 +399,6 @@
   "ban": "zbanować",
   "timestamp": "znacznik czasu",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/pt/default.json
+++ b/public/translations/pt/default.json
@@ -400,5 +400,5 @@
   "timestamp": "marca de tempo",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "vídeo do YouTube"
 }

--- a/public/translations/pt/default.json
+++ b/public/translations/pt/default.json
@@ -399,5 +399,6 @@
   "ban": "banir",
   "timestamp": "marca de tempo",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ro/default.json
+++ b/public/translations/ro/default.json
@@ -399,5 +399,6 @@
   "ban": "interzice",
   "timestamp": "marcă de timp",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/ro/default.json
+++ b/public/translations/ro/default.json
@@ -400,5 +400,5 @@
   "timestamp": "marcă de timp",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/ru/default.json
+++ b/public/translations/ru/default.json
@@ -400,5 +400,5 @@
   "timestamp": "временная метка",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "видео YouTube"
 }

--- a/public/translations/ru/default.json
+++ b/public/translations/ru/default.json
@@ -399,5 +399,6 @@
   "ban": "блокировка",
   "timestamp": "временная метка",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/sq/default.json
+++ b/public/translations/sq/default.json
@@ -400,5 +400,5 @@
   "timestamp": "vulë kohe",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/sq/default.json
+++ b/public/translations/sq/default.json
@@ -399,5 +399,6 @@
   "ban": "ndalim",
   "timestamp": "vulë kohe",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/sv/default.json
+++ b/public/translations/sv/default.json
@@ -399,5 +399,6 @@
   "ban": "förbjud",
   "timestamp": "tidsstämpel",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/sv/default.json
+++ b/public/translations/sv/default.json
@@ -400,5 +400,5 @@
   "timestamp": "tidsstämpel",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube-video"
 }

--- a/public/translations/te/default.json
+++ b/public/translations/te/default.json
@@ -400,5 +400,5 @@
   "timestamp": "టైమ్‌స్టాంప్",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube వీడియో"
 }

--- a/public/translations/te/default.json
+++ b/public/translations/te/default.json
@@ -399,5 +399,6 @@
   "ban": "నిషేధం",
   "timestamp": "టైమ్‌స్టాంప్",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/th/default.json
+++ b/public/translations/th/default.json
@@ -400,5 +400,5 @@
   "timestamp": "แสตมป์เวลา",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "วิดีโอ YouTube"
 }

--- a/public/translations/th/default.json
+++ b/public/translations/th/default.json
@@ -399,5 +399,6 @@
   "ban": "แบน",
   "timestamp": "แสตมป์เวลา",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/tr/default.json
+++ b/public/translations/tr/default.json
@@ -400,5 +400,5 @@
   "timestamp": "zaman damgası",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube videosu"
 }

--- a/public/translations/tr/default.json
+++ b/public/translations/tr/default.json
@@ -399,5 +399,6 @@
   "ban": "yasakla",
   "timestamp": "zaman damgası",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/uk/default.json
+++ b/public/translations/uk/default.json
@@ -399,5 +399,6 @@
   "ban": "заблокувати",
   "timestamp": "часова мітка",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/uk/default.json
+++ b/public/translations/uk/default.json
@@ -400,5 +400,5 @@
   "timestamp": "часова мітка",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "відео YouTube"
 }

--- a/public/translations/ur/default.json
+++ b/public/translations/ur/default.json
@@ -400,5 +400,5 @@
   "timestamp": "ٹائم سٹیمپ",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube ویڈیو"
 }

--- a/public/translations/ur/default.json
+++ b/public/translations/ur/default.json
@@ -399,5 +399,6 @@
   "ban": "روک",
   "timestamp": "ٹائم سٹیمپ",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/vi/default.json
+++ b/public/translations/vi/default.json
@@ -400,5 +400,5 @@
   "timestamp": "dấu thời gian",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "video YouTube"
 }

--- a/public/translations/vi/default.json
+++ b/public/translations/vi/default.json
@@ -399,5 +399,6 @@
   "ban": "cấm",
   "timestamp": "dấu thời gian",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/zh/default.json
+++ b/public/translations/zh/default.json
@@ -399,5 +399,6 @@
   "ban": "封禁",
   "timestamp": "时间戳",
   "tag": "tag",
-  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled."
+  "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
+  "youtube_video": "youtube video"
 }

--- a/public/translations/zh/default.json
+++ b/public/translations/zh/default.json
@@ -400,5 +400,5 @@
   "timestamp": "时间戳",
   "tag": "tag",
   "post_form_flash_upload_prompt": "Recommended SWF host: <catbox>Catbox</catbox>. Upload a .swf, then paste the direct https://files.catbox.moe/...swf link in Link. Other hosts must provide a direct HTTPS .swf URL with CORS enabled.",
-  "youtube_video": "youtube video"
+  "youtube_video": "YouTube 视频"
 }

--- a/src/components/__tests__/post-community-address-compat.test.tsx
+++ b/src/components/__tests__/post-community-address-compat.test.tsx
@@ -151,6 +151,8 @@ vi.mock('../../lib/utils/media-utils', () => ({
   getDisplayMediaInfoType: (type?: string) => type ?? 'unknown',
   getHasThumbnail: () => true,
   getMediaDimensions: () => '100x100',
+  getPostMediaTypeLabel: (_commentMediaInfo: unknown, resolvedType?: string) => resolvedType ?? '',
+  getYouTubeEmbedPostMediaFileLink: () => undefined,
 }));
 
 vi.mock('../../lib/utils/post-utils', () => ({
@@ -171,6 +173,7 @@ vi.mock('../../lib/utils/pending-approval-moderation', () => ({
 
 vi.mock('../../lib/utils/url-utils', () => ({
   isValidURL: () => true,
+  parseHttpUrl: (value: string) => new URL(value),
 }));
 
 vi.mock('../../lib/utils/view-utils', () => ({

--- a/src/components/comment-content/__tests__/comment-content.test.tsx
+++ b/src/components/comment-content/__tests__/comment-content.test.tsx
@@ -408,11 +408,11 @@ describe('CommentContent', () => {
       cid: 'post-2',
       content: 'ignored',
       postCid: 'post-2',
-      reason: 'spam',
+      reason: 'duplicate of >>96',
       removed: true,
     });
     expect(container.textContent).toContain('this_post_was_removed');
-    expect(container.textContent).toContain('Reason: "spam"');
+    expect(queryMarkdownText()).toEqual(['Reason: duplicate of >>96']);
 
     await renderContent({
       cid: 'post-3',
@@ -422,7 +422,7 @@ describe('CommentContent', () => {
       reason: 'self-delete',
     });
     expect(container.textContent).toContain('user_deleted_this_post');
-    expect(container.textContent).toContain('Reason: "self-delete"');
+    expect(queryMarkdownText()).toEqual(['Reason: self-delete']);
   });
 
   it('renders pending approval, ban details, and loading or failed states', async () => {
@@ -442,6 +442,7 @@ describe('CommentContent', () => {
 
     expect(container.textContent).toContain('pending_mod_approval');
     expect(container.textContent).toContain('pending-reason:rules violation');
+    expect(queryMarkdownText()).toEqual(['queued body', 'pending-reason:rules violation']);
     const tooltip = container.querySelector('[data-testid="tooltip"]');
     expect(tooltip?.getAttribute('title')).toContain('ban:short:music-posting.eth:2024-01-01 12:00:00');
 

--- a/src/components/comment-content/comment-content.tsx
+++ b/src/components/comment-content/comment-content.tsx
@@ -156,7 +156,14 @@ const CommentContent = ({
   const failedError = getFailedCommentError(resolvedPost);
   const failedErrorMessage = formatErrorMessageForDisplay(failedError);
   const shouldShowUnpublishedStateDetails = !cid && (!hasFailedState || Boolean(failedError));
+  const reasonMessage = reason ? `${capitalize(t('reason'))}: ${reason}` : undefined;
   const pendingApprovalReason = pendingApproval ? reason?.trim() : undefined;
+  const pendingApprovalReasonMessage = pendingApprovalReason
+    ? t('pending_mod_approval_reason', {
+        reason: pendingApprovalReason,
+        interpolation: { escapeValue: false },
+      })
+    : undefined;
 
   const loadingString = (
     <div className={styles.stateString}>
@@ -193,21 +200,21 @@ const CommentContent = ({
       {purged ? (
         <span className={styles.grayEditMessage}>{capitalize(t('this_post_was_purged'))}</span>
       ) : removed ? (
-        reason ? (
+        reasonMessage ? (
           <>
             <span className={styles.redEditMessage}>({t('this_post_was_removed')})</span>
             <br />
             <br />
-            <span className={styles.grayEditMessage}>{`${capitalize(t('reason'))}: "${reason}"`}</span>
+            {renderContent(reasonMessage)}
           </>
         ) : (
           <span className={styles.grayEditMessage}>{capitalize(t('this_post_was_removed'))}.</span>
         )
       ) : deleted ? (
-        reason ? (
+        reasonMessage ? (
           <>
             <span className={styles.grayEditMessage}>{t('user_deleted_this_post')}</span>{' '}
-            <span className={styles.grayEditMessage}>{`${capitalize(t('reason'))}: "${reason}"`}</span>
+            {renderContent(reasonMessage)}
           </>
         ) : (
           <span className={styles.grayEditMessage}>{t('user_deleted_this_post')}</span>
@@ -220,18 +227,13 @@ const CommentContent = ({
               <br />
               <br />
               <span className={styles.pendingApproval}>({t('pending_mod_approval')})</span>
-              {pendingApprovalReason && (
+              {pendingApprovalReasonMessage ? (
                 <>
                   <br />
                   <br />
-                  <span className={styles.grayEditMessage}>
-                    {t('pending_mod_approval_reason', {
-                      reason: pendingApprovalReason,
-                      interpolation: { escapeValue: false },
-                    })}
-                  </span>
+                  {renderContent(pendingApprovalReasonMessage)}
                 </>
-              )}
+              ) : null}
             </>
           )}
           {((!isInPostView && content?.length > 1000 && !showFullComment) || (isInPostView && content?.length > 2000 && !showFullComment)) && !isPrivilegedAuthor && (

--- a/src/components/comment-media/__tests__/comment-media.test.tsx
+++ b/src/components/comment-media/__tests__/comment-media.test.tsx
@@ -295,6 +295,21 @@ describe('CommentMedia', () => {
     expect(setShowThumbnailMock).toHaveBeenCalledWith(false);
   });
 
+  it('renders a youtube thumbnail before the embed is opened', async () => {
+    await renderMedia({
+      commentMediaInfo: {
+        patternThumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+        type: 'iframe',
+        url: 'https://www.youtube.com/watch?v=abc123',
+      },
+      setShowThumbnail: setShowThumbnailMock,
+      showThumbnail: true,
+    });
+
+    expect(container.querySelector('img[src="https://img.youtube.com/vi/abc123/0.jpg"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="embed"]')).toBeNull();
+  });
+
   it('renders the expanded embed view with a close button on mobile', async () => {
     testState.isMobile = true;
 

--- a/src/components/embed/__tests__/embed.test.tsx
+++ b/src/components/embed/__tests__/embed.test.tsx
@@ -3,7 +3,7 @@ import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Embed from '../embed';
-import { canEmbed } from '../embed-utils';
+import { canEmbed, getYouTubeVideoId } from '../embed-utils';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 const act = (React as { act?: (cb: () => void | Promise<void>) => void | Promise<void> }).act as (cb: () => void | Promise<void>) => void | Promise<void>;
@@ -54,6 +54,14 @@ describe('Embed', () => {
     await renderEmbed('https://example.com/plain-link');
 
     expect(container.innerHTML).toBe('');
+  });
+
+  it('extracts youtube video ids for standard, short, and invidious urls', () => {
+    expect(getYouTubeVideoId(new URL('https://www.youtube.com/watch?v=abc123'))).toBe('abc123');
+    expect(getYouTubeVideoId(new URL('https://youtu.be/short123'))).toBe('short123');
+    expect(getYouTubeVideoId(new URL('https://www.youtube.com/shorts/short456'))).toBe('short456');
+    expect(getYouTubeVideoId(new URL('https://yewtu.be/invidious789'))).toBe('invidious789');
+    expect(getYouTubeVideoId(new URL('https://www.youtube.com/playlist?list=PL123'))).toBeNull();
   });
 
   it('reports embeddable hosts through canEmbed and rejects unsupported reddit pages', () => {

--- a/src/components/embed/__tests__/embed.test.tsx
+++ b/src/components/embed/__tests__/embed.test.tsx
@@ -58,9 +58,13 @@ describe('Embed', () => {
 
   it('extracts youtube video ids for standard, short, and invidious urls', () => {
     expect(getYouTubeVideoId(new URL('https://www.youtube.com/watch?v=abc123'))).toBe('abc123');
+    expect(getYouTubeVideoId(new URL('https://m.youtube.com/watch?v=mobile123'))).toBe('mobile123');
+    expect(getYouTubeVideoId(new URL('https://music.youtube.com/watch?v=music123'))).toBe('music123');
     expect(getYouTubeVideoId(new URL('https://youtu.be/short123'))).toBe('short123');
     expect(getYouTubeVideoId(new URL('https://www.youtube.com/shorts/short456'))).toBe('short456');
     expect(getYouTubeVideoId(new URL('https://yewtu.be/invidious789'))).toBe('invidious789');
+    expect(getYouTubeVideoId(new URL('https://m.youtube.com/@channel'))).toBeNull();
+    expect(getYouTubeVideoId(new URL('https://music.youtube.com/channel/UC123'))).toBeNull();
     expect(getYouTubeVideoId(new URL('https://www.youtube.com/playlist?list=PL123'))).toBeNull();
   });
 

--- a/src/components/embed/embed-utils.ts
+++ b/src/components/embed/embed-utils.ts
@@ -1,4 +1,4 @@
-const STANDARD_YOUTUBE_HOSTS = new Set<string>(['youtube.com', 'www.youtube.com', 'youtu.be', 'www.youtu.be']);
+const STANDARD_YOUTUBE_HOSTS = new Set<string>(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtu.be', 'www.youtu.be']);
 
 export const youtubeHosts = new Set<string>([
   'youtube.com',

--- a/src/components/embed/embed-utils.ts
+++ b/src/components/embed/embed-utils.ts
@@ -1,3 +1,5 @@
+const STANDARD_YOUTUBE_HOSTS = new Set<string>(['youtube.com', 'www.youtube.com', 'youtu.be', 'www.youtu.be']);
+
 export const youtubeHosts = new Set<string>([
   'youtube.com',
   'www.youtube.com',
@@ -45,6 +47,35 @@ const canEmbedHosts = new Set<string>([
   ...streamableHosts,
   ...spotifyHosts,
 ]);
+
+export const getYouTubeVideoId = (parsedUrl: URL): string | null => {
+  if (parsedUrl.searchParams.has('list') && !parsedUrl.searchParams.get('v') && !parsedUrl.host.includes('youtu.be') && !parsedUrl.pathname.includes('/shorts/')) {
+    return null;
+  }
+
+  const videoIdFromQuery = parsedUrl.searchParams.get('v');
+  if (videoIdFromQuery) {
+    return videoIdFromQuery;
+  }
+
+  if (parsedUrl.host.includes('youtu.be')) {
+    return parsedUrl.pathname.slice(1).split('/')[0] || null;
+  }
+
+  if (parsedUrl.pathname.includes('/shorts/')) {
+    return parsedUrl.pathname.split('/shorts/')[1]?.split('/')[0] || null;
+  }
+
+  const isInvidious = !STANDARD_YOUTUBE_HOSTS.has(parsedUrl.host) && (youtubeHosts.has(parsedUrl.host) || parsedUrl.host.startsWith('yt.'));
+  if (isInvidious) {
+    if (parsedUrl.pathname.startsWith('/watch')) {
+      return parsedUrl.searchParams.get('v');
+    }
+    return parsedUrl.pathname.split('/').filter(Boolean).pop() || null;
+  }
+
+  return null;
+};
 
 export const canEmbed = (parsedUrl: URL): boolean => {
   if (xHosts.has(parsedUrl.host)) {

--- a/src/components/embed/embed.tsx
+++ b/src/components/embed/embed.tsx
@@ -10,6 +10,7 @@ import {
   streamableHosts,
   tiktokHosts,
   twitchHosts,
+  getYouTubeVideoId,
   xHosts,
   youtubeHosts,
 } from './embed-utils';
@@ -66,28 +67,11 @@ const remoteEmbedSandbox = `${srcDocSandbox} allow-forms allow-presentation allo
 const YoutubeEmbed = ({ parsedUrl }: EmbedComponentProps) => {
   let embedSrc = '';
 
-  const isInvidious = parsedUrl.host !== 'youtube.com' && parsedUrl.host !== 'www.youtube.com' && parsedUrl.host !== 'youtu.be' && parsedUrl.host !== 'www.youtu.be';
-
-  if (parsedUrl.searchParams.has('list')) {
+  if (parsedUrl.searchParams.has('list') && !getYouTubeVideoId(parsedUrl)) {
     const playlistId = parsedUrl.searchParams.get('list');
     embedSrc = `https://www.youtube.com/embed/videoseries?list=${playlistId}`;
   } else {
-    let videoId = parsedUrl.searchParams.get('v');
-
-    if (!videoId) {
-      if (parsedUrl.host.includes('youtu.be')) {
-        videoId = parsedUrl.pathname.substring(1);
-      } else if (parsedUrl.pathname.includes('/shorts/')) {
-        videoId = parsedUrl.pathname.split('/shorts/')[1];
-      } else if (isInvidious) {
-        if (parsedUrl.pathname.startsWith('/watch')) {
-          videoId = parsedUrl.searchParams.get('v');
-        } else {
-          videoId = parsedUrl.pathname.split('/').pop() || null;
-        }
-      }
-    }
-
+    const videoId = getYouTubeVideoId(parsedUrl);
     if (videoId) {
       embedSrc = `https://www.youtube.com/embed/${videoId}`;
     }

--- a/src/components/embed/index.ts
+++ b/src/components/embed/index.ts
@@ -1,2 +1,2 @@
 export { default } from './embed';
-export { canEmbed } from './embed-utils';
+export { canEmbed, getYouTubeVideoId } from './embed-utils';

--- a/src/components/markdown/__tests__/markdown.test.tsx
+++ b/src/components/markdown/__tests__/markdown.test.tsx
@@ -61,7 +61,7 @@ vi.mock('@floating-ui/react', () => ({
   useFocus: () => ({}),
   useHover: () => ({
     getReferenceProps: (props?: Record<string, unknown>) => ({
-      ...(props || {}),
+      ...props,
       onMouseEnter: () => testState.floatingOnOpenChange?.(true),
       onMouseLeave: () => testState.floatingOnOpenChange?.(false),
     }),

--- a/src/components/markdown/__tests__/markdown.test.tsx
+++ b/src/components/markdown/__tests__/markdown.test.tsx
@@ -24,7 +24,9 @@ const testState = vi.hoisted(() => ({
   cidToNumber: {} as Record<string, number>,
   internalPathByHref: {} as Record<string, string | null>,
   isMobile: false,
-  mediaInfoByHref: {} as Record<string, { thumbnail?: string; type: string; url: string }>,
+  mediaInfoByHref: {} as Record<string, { patternThumbnailUrl?: string; thumbnail?: string; type: string; url: string }>,
+  floatingMediaProps: null as { showThumbnail?: boolean } | null,
+  floatingOnOpenChange: null as ((open: boolean) => void) | null,
   numberToCid: {} as Record<string, Record<number, string>>,
   unavailableCids: new Set<string>(),
 }));
@@ -42,20 +44,32 @@ vi.mock('@floating-ui/react', () => ({
   shift: () => ({}),
   size: () => ({}),
   useDismiss: () => ({}),
-  useFloating: () => ({
-    context: {},
-    floatingStyles: {},
-    refs: {
-      setFloating: () => undefined,
-      setReference: () => undefined,
-    },
-    update: () => undefined,
-  }),
+  useFloating: ({ onOpenChange, open }: { onOpenChange?: (open: boolean) => void; open?: boolean }) => {
+    testState.floatingOnOpenChange = onOpenChange ?? null;
+    return {
+      context: {},
+      floatingStyles: {},
+      open,
+      onOpenChange,
+      refs: {
+        setFloating: () => undefined,
+        setReference: () => undefined,
+      },
+      update: () => undefined,
+    };
+  },
   useFocus: () => ({}),
-  useHover: () => ({}),
-  useInteractions: () => ({
+  useHover: () => ({
+    getReferenceProps: (props?: Record<string, unknown>) => ({
+      ...(props || {}),
+      onMouseEnter: () => testState.floatingOnOpenChange?.(true),
+      onMouseLeave: () => testState.floatingOnOpenChange?.(false),
+    }),
+  }),
+  useInteractions: (interactions: Array<{ getReferenceProps?: (props?: Record<string, unknown>) => Record<string, unknown> }>) => ({
     getFloatingProps: (props?: Record<string, unknown>) => props || {},
-    getReferenceProps: (props?: Record<string, unknown>) => props || {},
+    getReferenceProps: (props?: Record<string, unknown>) =>
+      interactions.reduce((mergedProps, interaction) => interaction.getReferenceProps?.(mergedProps) || mergedProps, props || {}),
   }),
 }));
 
@@ -75,8 +89,13 @@ vi.mock('../../../hooks/use-is-mobile', () => ({
 }));
 
 vi.mock('../../../lib/utils/media-utils', () => ({
-  getHasThumbnail: (linkMediaInfo?: { thumbnail?: string; type?: string }, href?: string) =>
-    Boolean(linkMediaInfo?.thumbnail || linkMediaInfo?.type === 'image' || (href && testState.mediaInfoByHref[href]?.thumbnail)),
+  getHasThumbnail: (linkMediaInfo?: { patternThumbnailUrl?: string; thumbnail?: string; type?: string }, href?: string) =>
+    Boolean(
+      linkMediaInfo?.thumbnail ||
+      linkMediaInfo?.patternThumbnailUrl ||
+      linkMediaInfo?.type === 'image' ||
+      (href && (testState.mediaInfoByHref[href]?.thumbnail || testState.mediaInfoByHref[href]?.patternThumbnailUrl)),
+    ),
   getLinkMediaInfo: (href: string) => testState.mediaInfoByHref[href],
 }));
 
@@ -139,8 +158,28 @@ vi.mock('../../../stores/use-post-number-store', () => ({
 }));
 
 vi.mock('../../comment-media', () => ({
-  default: ({ commentMediaInfo }: { commentMediaInfo?: { type?: string; url?: string } }) =>
-    createElement('div', { 'data-testid': 'comment-media' }, `${commentMediaInfo?.type}:${commentMediaInfo?.url}`),
+  default: ({
+    commentMediaInfo,
+    isFloatingEmbed,
+    showThumbnail,
+  }: {
+    commentMediaInfo?: { type?: string; url?: string };
+    isFloatingEmbed?: boolean;
+    showThumbnail?: boolean;
+  }) => {
+    if (isFloatingEmbed) {
+      testState.floatingMediaProps = { showThumbnail };
+    }
+    return createElement(
+      'div',
+      {
+        'data-floating': String(Boolean(isFloatingEmbed)),
+        'data-show-thumbnail': String(showThumbnail),
+        'data-testid': 'comment-media',
+      },
+      `${commentMediaInfo?.type}:${commentMediaInfo?.url}`,
+    );
+  },
 }));
 
 vi.mock('../../embed', () => ({
@@ -198,6 +237,8 @@ describe('Markdown', () => {
     testState.internalPathByHref = {};
     testState.isMobile = false;
     testState.mediaInfoByHref = {};
+    testState.floatingMediaProps = null;
+    testState.floatingOnOpenChange = null;
     testState.numberToCid = {};
     testState.unavailableCids = new Set<string>();
 
@@ -458,6 +499,33 @@ describe('Markdown', () => {
 
     const lazyLinks = Array.from(container.querySelectorAll('[data-testid="external-number-quote-link"]'));
     expect(lazyLinks.map((node) => node.textContent)).toEqual(['>>42', '>>>/fit/77']);
+  });
+
+  it('shows youtube thumbnails in the floating hover preview instead of loading the iframe', async () => {
+    testState.embeddableHosts = new Set(['www.youtube.com']);
+    testState.mediaInfoByHref = {
+      'https://www.youtube.com/watch?v=abc123': {
+        patternThumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+        type: 'iframe',
+        url: 'https://www.youtube.com/watch?v=abc123',
+      },
+    };
+
+    await renderMarkdown({
+      content: 'https://www.youtube.com/watch?v=abc123',
+    });
+
+    const embedButton = Array.from(container.querySelectorAll('button')).find((node) => node.textContent === 'embed');
+    expect(embedButton).toBeTruthy();
+
+    await act(async () => {
+      testState.floatingOnOpenChange?.(true);
+    });
+
+    const floatingMedia = container.querySelector('[data-floating="true"]');
+    expect(floatingMedia).toBeTruthy();
+    expect(floatingMedia?.getAttribute('data-show-thumbnail')).toBe('true');
+    expect(testState.floatingMediaProps?.showThumbnail).toBe(true);
   });
 
   it('toggles inline media embeds for embeddable links outside catalog view', async () => {

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -123,8 +123,8 @@ const ContentLinkEmbed = ({ children, href, linkMediaInfo }: ContentLinkEmbedPro
                 disableToggle={true}
                 isFloatingEmbed={true}
                 isReply={false}
-                setShowThumbnail={setShowMedia}
-                showThumbnail={false}
+                setShowThumbnail={() => {}}
+                showThumbnail={true}
               />
             </div>
           )}

--- a/src/components/post-desktop/post-desktop.tsx
+++ b/src/components/post-desktop/post-desktop.tsx
@@ -5,11 +5,11 @@ import { Virtuoso, VirtuosoHandle, StateSnapshot } from 'react-virtuoso';
 import { Comment, useEditedComment, useReplies, useAccount } from '@bitsocial/bitsocial-react-hooks';
 import getShortAddress from '../../lib/get-short-address';
 import styles from '../../views/post/post.module.css';
-import { CommentMediaInfo, getDisplayMediaInfoType, getHasThumbnail, getMediaDimensions } from '../../lib/utils/media-utils';
+import { CommentMediaInfo, getHasThumbnail, getMediaDimensions, getPostMediaTypeLabel, getYouTubeEmbedPostMediaFileLink } from '../../lib/utils/media-utils';
 import { hashStringToColor, getTextColorForBackground } from '../../lib/utils/post-utils';
 import { getFormattedDate, getFormattedTimeAgo } from '../../lib/utils/time-utils';
 import { approvePendingCommentModeration, isPendingApprovalRejected, rejectPendingCommentModeration } from '../../lib/utils/pending-approval-moderation';
-import { isValidURL } from '../../lib/utils/url-utils';
+import { isValidURL, parseHttpUrl } from '../../lib/utils/url-utils';
 import { isAllView, isModQueueView, isModView, isPendingPostView, isPostPageView, isSubscriptionsView } from '../../lib/utils/view-utils';
 import { formatUserIDForDisplay, truncateWithEllipsisInMiddle } from '../../lib/utils/string-utils';
 import useModQueueStore from '../../stores/use-mod-queue-store';
@@ -642,12 +642,16 @@ const PostMedia = ({
     type = 'static gif';
   }
 
-  const embedUrl = url && new URL(url);
+  const youtubeFileLink = getYouTubeEmbedPostMediaFileLink(commentMediaInfo);
+  const fileLinkUrl = youtubeFileLink ?? url;
+  const embedUrl = url ? parseHttpUrl(url) : null;
   const [showThumbnail, setShowThumbnail] = useState(true);
 
   const mediaDimensions = getMediaDimensions(commentMediaInfo);
   const directoryEntry = findDirectoryByAddress(directories, communityAddress);
   const requirePostLinkIsMedia = directoryEntry?.features?.requirePostLinkIsMedia === true;
+  const fileLabel = youtubeFileLink || requirePostLinkIsMedia ? t('file') : t('link');
+  const mediaTypeLabel = type ? lowerCase(getPostMediaTypeLabel(commentMediaInfo, type, t)) : '';
   const boardPath = communityAddress ? getBoardPath(communityAddress, directories) : undefined;
   const displayBoardPath =
     boardPath && communityAddress && boardPath !== communityAddress
@@ -666,10 +670,11 @@ const PostMedia = ({
             {t('board')}: <Link to={`/${boardPath}`}>{displayBoardPath}</Link>{' '}
           </>
         )}
-        {requirePostLinkIsMedia ? t('file') : t('link')}:{' '}
-        <a href={url} target='_blank' rel='noopener noreferrer'>
+        {fileLabel}:{' '}
+        <a href={fileLinkUrl} target='_blank' rel='noopener noreferrer'>
           {(() => {
             if (spoiler) return capitalize(t('spoiler'));
+            if (youtubeFileLink) return truncateWithEllipsisInMiddle(youtubeFileLink);
             if (requirePostLinkIsMedia && url) {
               try {
                 const pathParts = new URL(url).pathname.split('/');
@@ -677,10 +682,10 @@ const PostMedia = ({
                 if (filename && /\.\w+$/.test(filename)) return truncateWithEllipsisInMiddle(filename);
               } catch {}
             }
-            return truncateWithEllipsisInMiddle(url ?? '');
+            return truncateWithEllipsisInMiddle(fileLinkUrl ?? '');
           })()}
         </a>{' '}
-        ({type && lowerCase(getDisplayMediaInfoType(type, t))}
+        ({mediaTypeLabel}
         {mediaDimensions && `, ${mediaDimensions}`})
         {!showThumbnail && (type === 'iframe' || type === 'video' || type === 'audio') && (
           <span>

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -444,6 +444,7 @@ describe('PostForm', () => {
     testState.directories = [
       { address: 'music-posting.eth', features: {}, title: '/mu/ - Music' },
       { address: 'politically-incorrect.bso', directoryCode: 'pol', features: { hasFlags: true }, title: '/pol/ - Politically Incorrect' },
+      { address: 'sports-posting.bso', directoryCode: 'sp', features: { hasFlags: true }, title: '/sp/ - Sports' },
       { address: 'random-nsfw.bso', features: {}, title: '/b/ - Random' },
       {
         address: 'flash-posting.bso',
@@ -692,6 +693,30 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
       content: 'flagged post',
+      challengeRequest: {
+        challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
+      },
+      flairs: [{ type: 'country', code: 'auto', text: 'flag:country:auto' }],
+    });
+  });
+
+  it('publishes geographic location on /sp/ without showing a flag field', async () => {
+    testState.resolvedCommunityAddress = 'sports-posting.bso';
+
+    await renderPostForm('/sp');
+    await clickByText(container, 'start_new_thread');
+
+    const table = container.querySelector('table');
+    const flagSelect = table?.querySelector<HTMLSelectElement>('select[aria-label="flag"]');
+    const textarea = table?.querySelector<HTMLTextAreaElement>('textarea');
+
+    expect(flagSelect).toBeNull();
+
+    await dispatchInput(textarea as HTMLTextAreaElement, 'sports post');
+    await clickByText(table as HTMLTableElement, 'post');
+
+    expect(testState.publishPostMock).toHaveBeenCalledWith({
+      content: 'sports post',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -391,7 +391,7 @@ const PostFormFields = ({
       <tr>
         <td>{t('tag')}</td>
         <td>
-          <select name='flashTag' aria-label={t('tag')} ref={flashTagRef} defaultValue=''>
+          <select name='flashTag' aria-label={t('tag')} className={styles.flagSelector} ref={flashTagRef} defaultValue=''>
             <option value=''>{t('choose_one')}</option>
             {flashTagOptions.map((option) => (
               <option key={option.value} value={option.value}>

--- a/src/components/reply-modal/__tests__/reply-modal.test.tsx
+++ b/src/components/reply-modal/__tests__/reply-modal.test.tsx
@@ -340,6 +340,18 @@ describe('ReplyModal', () => {
         features: { hasFlags: true },
         title: '/bant/ - International/Random',
       },
+      'international-sfw.bso': {
+        address: 'international-sfw.bso',
+        directoryCode: 'int',
+        features: { hasFlags: true },
+        title: '/int/ - International',
+      },
+      'sports-posting.bso': {
+        address: 'sports-posting.bso',
+        directoryCode: 'sp',
+        features: { hasFlags: true },
+        title: '/sp/ - Sports',
+      },
       'random-nsfw.bso': {
         address: 'random-nsfw.bso',
         features: {},
@@ -494,8 +506,12 @@ describe('ReplyModal', () => {
     });
   });
 
-  it('publishes geographic location on /bant/ without showing a flag selector', async () => {
-    await renderReplyModal('/bant/thread/post-1', 'international-nsfw.bso');
+  it.each([
+    { boardPath: '/bant/thread/post-1', communityAddress: 'international-nsfw.bso' },
+    { boardPath: '/int/thread/post-1', communityAddress: 'international-sfw.bso' },
+    { boardPath: '/sp/thread/post-1', communityAddress: 'sports-posting.bso' },
+  ])('publishes geographic location on country-only boards without showing a flag selector', async ({ boardPath, communityAddress }) => {
+    await renderReplyModal(boardPath, communityAddress);
 
     expect(container.querySelector<HTMLSelectElement>('select[aria-label="flag"]')).toBeNull();
 

--- a/src/components/settings-modal/p2p-stats-settings/__tests__/p2p-stats-settings.test.tsx
+++ b/src/components/settings-modal/p2p-stats-settings/__tests__/p2p-stats-settings.test.tsx
@@ -256,6 +256,73 @@ describe('P2PStatsSettings', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://free.freeipapi.com/api/json/91.234.199.189', expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 
+  it('shows peer country flags for DNS6 relay hostnames with embedded IPv6 addresses', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'https://free.freeipapi.com/api/json/2a11%3A6100%3A0%3A5e9f%3A%3A0') {
+        return {
+          ok: true,
+          json: async () => ({
+            cityName: 'Reykjavik',
+            countryCode: 'IS',
+            ipAddress: '2a11:6100:0:5e9f::0',
+            latitude: 64.1466,
+            longitude: -21.9426,
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ country: 'US', ip: '147.75.84.175' }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    testState.account = {
+      ...testState.account,
+      pkcOptions: {
+        libp2pJsClientsOptions: [{ key: 'libp2pjs' }],
+      },
+      pkc: {
+        clients: {
+          libp2pJsClients: {
+            libp2pjs: {
+              key: 'libp2pjs',
+              _helia: {
+                libp2p: {
+                  getConnections: () => [
+                    {
+                      remoteAddr: {
+                        toString: () => '/dns6/2a11-6100-0-5e9f--0.k51qzi5uqu5djg5pdoi9a98.example/tcp/443/ws/p2p/relay-peer/p2p-circuit/p2p/12D3KooWIPv6Peer',
+                      },
+                      remotePeer: { toString: () => '12D3KooWIPv6Peer' },
+                    },
+                  ],
+                  getMultiaddrs: () => ['/ip4/147.75.84.175/tcp/4001/ws'],
+                  getPeers: () => ['12D3KooWIPv6Peer'],
+                  peerId: { toString: () => 'self-peer' },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    await renderSettings(false);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const connectedPeers = container.querySelector('[data-testid="connected-peers"]');
+    expect(connectedPeers?.textContent).toContain('WebSocket through relay');
+    expect(connectedPeers?.querySelector('img[aria-label="Iceland"]')).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://free.freeipapi.com/api/json/2a11%3A6100%3A0%3A5e9f%3A%3A0',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it('shows the own IP flag and a red precise map marker when leeching', async () => {
     const fetchMock = vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url);

--- a/src/lib/__tests__/comment-flag-selection.test.ts
+++ b/src/lib/__tests__/comment-flag-selection.test.ts
@@ -17,30 +17,34 @@ describe('comment-flag-selection', () => {
     expect(hasCommentFlagsForDirectory({ features: { hasFlags: true }, title: '/pol/ - Politically Incorrect' })).toBe(true);
   });
 
-  it('uses geographic location as the default for country flag boards', () => {
+  it('uses geographic location as the default for other flag boards', () => {
     expect(
       getCommentFlagOptionsForDirectory({
-        directoryCode: 'int',
+        directoryCode: 'fit',
         features: { hasFlags: true },
-        title: '/int/ - International',
+        title: '/fit/ - Fitness',
       }),
     ).toEqual([{ label: 'Geographic Location', value: 'country:auto' }]);
   });
 
-  it('does not expose a flag selector on /bant/ but still publishes geographic location', () => {
+  it.each([
+    { directoryCode: 'bant', title: '/bant/ - International/Random' },
+    { directoryCode: 'int', title: '/int/ - International' },
+    { directoryCode: 'sp', title: '/sp/ - Sports' },
+  ])('does not expose a flag selector on /$directoryCode/ but still publishes geographic location', ({ directoryCode, title }) => {
     expect(
       getCommentFlagOptionsForDirectory({
-        directoryCode: 'bant',
+        directoryCode,
         features: { hasFlags: true },
-        title: '/bant/ - International/Random',
+        title,
       }),
     ).toEqual([]);
 
     expect(
       getCommentFlagPublishOptionsForDirectory({
-        directoryCode: 'bant',
+        directoryCode,
         features: { hasFlags: true },
-        title: '/bant/ - International/Random',
+        title,
       }),
     ).toEqual({
       challengeRequest: {

--- a/src/lib/__tests__/peer-geo.test.ts
+++ b/src/lib/__tests__/peer-geo.test.ts
@@ -37,6 +37,13 @@ describe('extractIpv6FromAddress', () => {
     expect(extractIpv6FromAddress('/ip6/2001:4860:4860::8888/tcp/4001/ws')).toBe('2001:4860:4860::8888');
     expect(extractIpFromAddress('/ip6/2001:4860:4860::8888/tcp/4001/ws')).toBe('2001:4860:4860::8888');
   });
+
+  it('extracts an IPv6 embedded with dashes in a DNS hostname', () => {
+    const address = '/dns6/2a11-6100-0-5e9f--0.k51qzi5uqu5djg5pdoi9a98.example/tcp/443/wss/p2p/12D3KooWExample';
+
+    expect(extractIpv6FromAddress(address)).toBe('2a11:6100:0:5e9f::0');
+    expect(extractIpFromAddress(address)).toBe('2a11:6100:0:5e9f::0');
+  });
 });
 
 describe('isPrivateOrReservedIpv4', () => {
@@ -258,6 +265,31 @@ describe('fetchPeerMapLocation', () => {
 
     await expect(fetchPeerMapLocation('/ip4/10.0.0.1/tcp/4001')).resolves.toBeUndefined();
     expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves a peer location from a DNS6 hostname with an embedded IPv6', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        cityName: 'Reykjavik',
+        countryCode: 'IS',
+        ipAddress: '2a11:6100:0:5e9f::0',
+        latitude: 64.1466,
+        longitude: -21.9426,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchPeerMapLocation('/dns6/2a11-6100-0-5e9f--0.k51qzi5uqu5djg5pdoi9a98.example/tcp/443/wss')).resolves.toMatchObject({
+      countryCode: 'is',
+      label: 'Reykjavik, IS',
+      lat: 64.1466,
+      lon: -21.9426,
+      source: 'geoip',
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe('https://free.freeipapi.com/api/json/2a11%3A6100%3A0%3A5e9f%3A%3A0');
 
     vi.unstubAllGlobals();
   });

--- a/src/lib/comment-flag-selection.ts
+++ b/src/lib/comment-flag-selection.ts
@@ -38,7 +38,7 @@ const NO_FLAG_OPTION: CommentFlagSelectOption = {
 };
 
 /** Boards that always publish geographic location without showing a flag selector. */
-const AUTO_GEOGRAPHIC_FLAG_DIRECTORY_CODES = new Set(['bant']);
+const AUTO_GEOGRAPHIC_FLAG_DIRECTORY_CODES = new Set(['bant', 'int', 'sp']);
 
 const getDirectoryCode = (directory: Pick<DirectoryCommunity, 'directoryCode' | 'title'> | undefined): string | undefined => {
   const directoryCode = directory?.directoryCode?.trim().toLowerCase();

--- a/src/lib/peer-geo.ts
+++ b/src/lib/peer-geo.ts
@@ -284,7 +284,17 @@ export const extractIpv4FromAddress = (address: string): string | null => {
 
 export const extractIpv6FromAddress = (address: string): string | null => {
   const direct = /\/ip6\/([^/]+)/.exec(address);
-  return direct ? direct[1] : null;
+  if (direct) return direct[1];
+  const dns = /\/dns6\/([^/]+)/i.exec(address);
+  const firstLabel = dns?.[1]?.split('.')[0];
+  if (!firstLabel || !firstLabel.includes('-') || !/^[0-9a-f-]+$/i.test(firstLabel)) return null;
+  const candidate = firstLabel.replaceAll('-', ':').toLowerCase();
+  try {
+    new URL(`http://[${candidate}]/`);
+    return candidate;
+  } catch {
+    return null;
+  }
 };
 
 const parseOctets = (ip: string): number[] | null => {

--- a/src/lib/utils/__tests__/media-utils.test.ts
+++ b/src/lib/utils/__tests__/media-utils.test.ts
@@ -20,9 +20,13 @@ vi.mock('@bitsocial/bitsocial-react-hooks/dist/lib/localforage-lru/index.js', ()
   },
 }));
 
-vi.mock('../../../components/embed', () => ({
-  canEmbed: (url: URL) => testState.canEmbedHosts.has(url.hostname),
-}));
+vi.mock('../../../components/embed/embed-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../components/embed/embed-utils')>();
+  return {
+    ...actual,
+    canEmbed: (url: URL) => testState.canEmbedHosts.has(url.hostname),
+  };
+});
 
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
@@ -33,7 +37,16 @@ vi.mock('@capacitor/core', () => ({
   },
 }));
 
-import { fetchWebpageThumbnailIfNeeded, getCommentMediaInfo, getDisplayMediaInfoType, getHasThumbnail, getLinkMediaInfo, getMediaDimensions } from '../media-utils';
+import {
+  fetchWebpageThumbnailIfNeeded,
+  getCommentMediaInfo,
+  getDisplayMediaInfoType,
+  getHasThumbnail,
+  getLinkMediaInfo,
+  getMediaDimensions,
+  getPostMediaTypeLabel,
+  getYouTubeEmbedPostMediaFileLink,
+} from '../media-utils';
 
 const clearMemoizedCache = (fn: unknown) => {
   const memoized = fn as { clear?: () => void };
@@ -102,6 +115,18 @@ describe('media-utils', () => {
     expect(getDisplayMediaInfoType('unknown', t)).toBe('translated:webpage');
   });
 
+  it('uses the youtube thumbnail url for post media file links and labels', () => {
+    const mediaInfo = {
+      patternThumbnailUrl: 'https://img.youtube.com/vi/abc123/0.jpg',
+      type: 'iframe',
+      url: 'https://www.youtube.com/watch?v=abc123',
+    };
+
+    expect(getYouTubeEmbedPostMediaFileLink(mediaInfo)).toBe('https://img.youtube.com/vi/abc123/0.jpg');
+    expect(getPostMediaTypeLabel(mediaInfo, 'iframe', (key) => key)).toBe('youtube_video');
+    expect(getYouTubeEmbedPostMediaFileLink({ type: 'iframe', url: 'https://streamable.com/clip123' })).toBeUndefined();
+  });
+
   it('recognizes which media types expose thumbnails', () => {
     expect(getHasThumbnail(undefined, 'https://example.com/file.png')).toBe(false);
     expect(getHasThumbnail({ type: 'image', url: 'https://example.com/file.png' }, 'https://example.com/file.png')).toBe(true);
@@ -155,6 +180,12 @@ describe('media-utils', () => {
       patternThumbnailUrl: 'https://img.youtube.com/vi/yt123/0.jpg',
       type: 'iframe',
       url: 'https://yt.example/watch?v=yt123',
+    });
+    testState.canEmbedHosts = new Set(['yewtu.be']);
+    expect(getLinkMediaInfo('https://yewtu.be/invidious123')).toEqual({
+      patternThumbnailUrl: 'https://img.youtube.com/vi/invidious123/0.jpg',
+      type: 'iframe',
+      url: 'https://yewtu.be/invidious123',
     });
   });
 

--- a/src/lib/utils/media-utils.ts
+++ b/src/lib/utils/media-utils.ts
@@ -1,5 +1,5 @@
 import localForageLru from '@bitsocial/bitsocial-react-hooks/dist/lib/localforage-lru/index.js';
-import { canEmbed } from '../../components/embed';
+import { canEmbed, getYouTubeVideoId } from '../../components/embed/embed-utils';
 import memoize from 'memoizee';
 import { isPrivateNetworkHostname, isValidURL, parseHttpUrl } from './url-utils';
 import { Capacitor, CapacitorHttp } from '@capacitor/core';
@@ -40,6 +40,31 @@ export const getDisplayMediaInfoType = (type: string, t: Translate) => {
   }
 };
 
+export const getYouTubeEmbedPostMediaFileLink = (commentMediaInfo: CommentMediaInfo | undefined): string | undefined => {
+  if (!commentMediaInfo || commentMediaInfo.type !== 'iframe' || !commentMediaInfo.url) {
+    return undefined;
+  }
+
+  const parsedUrl = parseHttpUrl(commentMediaInfo.url);
+  if (!parsedUrl || !getYouTubeVideoId(parsedUrl)) {
+    return undefined;
+  }
+
+  return commentMediaInfo.patternThumbnailUrl || getPatternThumbnailUrl(parsedUrl);
+};
+
+export const getPostMediaTypeLabel = (commentMediaInfo: CommentMediaInfo | undefined, resolvedType: string | undefined, t: Translate): string => {
+  if (getYouTubeEmbedPostMediaFileLink(commentMediaInfo)) {
+    return t('youtube_video');
+  }
+
+  if (!resolvedType) {
+    return '';
+  }
+
+  return getDisplayMediaInfoType(resolvedType, t);
+};
+
 export const getHasThumbnail = memoize(
   (commentMediaInfo: CommentMediaInfo | undefined, link: string | undefined): boolean => {
     if (!link || !commentMediaInfo) return false;
@@ -54,17 +79,6 @@ export const getHasThumbnail = memoize(
   },
   { max: 1000 },
 );
-
-const getYouTubeVideoId = (url: URL): string | null => {
-  if (url.host.includes('youtu.be')) {
-    return url.pathname.slice(1);
-  } else if (url.pathname.includes('/shorts/')) {
-    return url.pathname.split('/shorts/')[1].split('/')[0];
-  } else if (url.searchParams.has('v')) {
-    return url.searchParams.get('v');
-  }
-  return null;
-};
 
 const getPatternThumbnailUrl = (url: URL): string | undefined => {
   const videoId = getYouTubeVideoId(url);


### PR DESCRIPTION
## Summary

- Restore thumbnail-first YouTube embeds in post media and markdown hover previews (hover shows `img.youtube.com` thumb again, not an autoplaying iframe).
- Centralize YouTube video ID parsing in `embed-utils` so thumbnails work for standard and Invidious-style URLs.
- Desktop `PostMedia` shows **File** with the thumbnail image URL and type **youtube video** instead of Link + iframe.

## Test plan

- [ ] Post a thread with a YouTube link as the OP link: file row shows File, thumbnail URL, `youtube video`, thumbnail visible, click expands embed.
- [ ] Hover a YouTube URL in post content (desktop): floating preview shows thumbnail, not iframe.
- [ ] `yarn test`, `yarn build`, `yarn lint`, `yarn type-check` (run in CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, media parsing, and i18n with broad test coverage; no auth or data-model changes.
> 
> **Overview**
> This PR restores **thumbnail-first YouTube handling** in posts and link hovers, and tightens related parsing and UI copy.
> 
> **YouTube embeds and media** — `getYouTubeVideoId` is centralized in `embed-utils` (watch, youtu.be, shorts, mobile/music hosts, Invidious). Embeds and `media-utils` use it for `img.youtube.com` thumbnails. Desktop **PostMedia** shows **File**, the thumbnail URL, and label **youtube video** instead of Link/iframe. Markdown floating link previews keep **thumbnails** (`showThumbnail: true`) instead of loading an iframe on hover.
> 
> **Moderation / display** — Removal, delete, and pending-mod **reason** text is rendered through markdown (no extra quotes); tests updated.
> 
> **Board flags** — `/int/` and `/sp/` join `/bant/` for auto geographic location without a visible flag selector; post/reply tests expanded.
> 
> **P2P geo** — IPv6 can be parsed from **DNS6** hostnames with dash-encoded addresses (peer map flags in settings).
> 
> Minor: `vitest --maxWorkers=4`, `youtube_video` i18n, flash tag select styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effe16f8a96d6eb44206bcb6ec414e4d9cf7b75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YouTube video translation strings for all supported languages
  * YouTube ID extraction now supports many URL formats; floating comment media shows YouTube thumbnails

* **Bug Fixes**
  * Improved display/formatting of comment removal and pending-approval reasons

* **Refactor**
  * Centralized YouTube parsing for reuse
  * Auto-publish geographic location extended to additional boards
  * Enhanced IPv6 extraction for DNS6 relay addresses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->