### PR TITLE
ci(react-doctor): official PR-review Action (inline comments + summary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,30 +76,6 @@ jobs:
       - name: Verify forge config
         run: node -e "import('./forge.config.js').then(c => console.log('Config loaded, makers:', c.default.makers?.length || 0)).catch(e => { console.error(e); process.exit(1); })"
 
-      - name: Detect React UI changes
-        id: react-ui-changes
-        if: github.event_name == 'pull_request'
-        run: |
-          git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD > changed-files.txt
-          cat changed-files.txt
-          if grep -Eq '^(src/(components|views|hooks|stores)/|src/app\.tsx|src/main\.tsx)' changed-files.txt; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Run React Doctor
-        if: github.event_name != 'pull_request'
-        run: yarn doctor
-
-      - name: Run React Doctor on changed React files
-        if: github.event_name == 'pull_request' && steps.react-ui-changes.outputs.changed == 'true'
-        run: yarn doctor --diff "${{ github.event.pull_request.base.sha }}" --annotations
-
-      - name: Skip React Doctor
-        if: github.event_name == 'pull_request' && steps.react-ui-changes.outputs.changed != 'true'
-        run: echo "Skipping React Doctor because this pull request did not change React UI source."
-
       - name: Install Chromium for smoke tests
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,28 @@
+# React Doctor PR review.
+# Reports only issues this PR INTRODUCES (diffed against the merge-base) as inline
+# review comments + a sticky summary. It reads doctor.config.jsonc, so the
+# React-Compiler rules we don't enforce stay suppressed (see that file and
+# docs/agent-playbooks/known-surprises.md). We do NOT chase the aggregate score.
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so React Doctor can diff against the merge-base for new-vs-existing
+      - uses: millionco/react-doctor@v1


### PR DESCRIPTION
## What

Adds the official **react-doctor GitHub Action** (`millionco/react-doctor@v1`) in a dedicated `.github/workflows/react-doctor.yml`. On every PR it diffs against the merge-base and reports **only newly-introduced** issues as **inline review comments + a sticky summary** (like CodeRabbit/Codecov) — more visible than the CLI `--annotations` markers we used before.

Removes the now-redundant react-doctor steps from `ci.yml` (detect-changes / `--diff --annotations` / skip, plus the push-time full scan) so react-doctor runs **once per PR**, not twice.

## Notes

- It reads the repo's `doctor.config.jsonc`, so the React-Compiler rules we deliberately don't enforce stay suppressed — PR comments should only flag *real new* issues (no-barrel-import, state-sync bugs, a11y, etc.), not compiler-coverage noise. Worth confirming on the first PR that touches React after this merges.
- `actions/checkout@v4` to match repo convention. The third-party Action has `pull-requests: write`; SHA-pinning it (Dependabot-managed) is a reasonable future hardening, consistent with the react-doctor docs.

## Why

Follows the decision (see `docs/agent-playbooks/known-surprises.md`) to use react-doctor as a **PR-diff reviewer**, not an aggregate score to chase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application runtime code. The third-party Action needs PR write permissions, which is expected for inline reviews.
> 
> **Overview**
> Moves **React Doctor** from inline steps in `ci.yml` into a dedicated **`.github/workflows/react-doctor.yml`** that runs **`millionco/react-doctor@v1`** on pull requests. The Action diffs against the merge-base and posts **only newly introduced** findings as **inline review comments** plus a sticky summary, instead of the previous CI logic (detect React UI paths, `yarn doctor` on push, conditional `--diff --annotations`, or skip).
> 
> The main **CI** workflow no longer runs React Doctor at all, so PRs get a single react-doctor pass via the new workflow rather than overlapping CLI checks. The workflow grants **`pull-requests: write`** and **`issues: write`** for review comments, uses **`fetch-depth: 0`** for merge-base diffs, and **`doctor.config.jsonc`** still applies via the Action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad39f4695f38d7711f1e1e8121cea8d9da501c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a dedicated GitHub Actions workflow for React quality checks, decoupling them from the main CI pipeline for improved clarity and efficiency in pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->