### PR TITLE
test(flags): correct stale pony AJ sprite x-coord expectation

### DIFF
--- a/src/lib/__tests__/comment-flags.test.ts
+++ b/src/lib/__tests__/comment-flags.test.ts
@@ -22,7 +22,7 @@ describe('comment-flags', () => {
 
     expect(flags.map((flag) => flag.key)).toEqual(['country:de', 'pol:AC', 'pony:AJ']);
     expect(flags[1]).toMatchObject({ label: 'Anarcho-Capitalist', x: 0, y: 0 });
-    expect(flags[2]).toMatchObject({ label: 'Applejack', x: 80, y: 0 });
+    expect(flags[2]).toMatchObject({ label: 'Applejack', x: 48, y: 0 });
   });
 
   it('labels the xx country flag as Tor traffic', () => {


### PR DESCRIPTION
## Problem

`master` CI is red. The pony sprite-coordinate remap (`cbdd4edf7`, "fix(flags): map pony flags to sprite sheet coordinates") moved the `AJ` (Applejack) flag to `x: 48` in `board-flags.ts` and updated `board-flags.test.ts` accordingly, but `comment-flags.test.ts` was missed — it still asserts the old `x: 80`. Since `comment-flags` derives pony coords from the same `board-flags` definitions, the assertion is stale and the full vitest suite ("Quality + Smoke") fails.

## Fix

One-line test change: `comment-flags.test.ts` pony AJ expectation `x: 80 → x: 48`, matching the live `board-flags.ts` definition (`AJ: [48, 0]`) and the already-passing `board-flags.test.ts`.

## Verification

`yarn test` (comment-flags, board-flags, comment-flag-selection — 25/25), `yarn type-check`, `yarn lint` all pass. Test-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion update; no runtime or flag-rendering logic changed.
> 
> **Overview**
> Aligns **`comment-flags.test.ts`** with the pony sprite remap already reflected in **`board-flags`**: the Applejack (`flag:pony:AJ`) view-model expectation changes from **`x: 80`** to **`x: 48`** (with **`y: 0`** unchanged).
> 
> No production code changes—only fixes a stale assertion that was breaking CI after **`board-flags.test.ts`** was updated in the same remap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b73041da9dad4c7b1e1a33783770e3a8f3d17f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertion to ensure accurate validation of component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->