### PR TITLE
Fix cross-thread fresh reply matching

### DIFF
--- a/src/components/post-desktop/post-desktop.tsx
+++ b/src/components/post-desktop/post-desktop.tsx
@@ -939,7 +939,7 @@ const PostDesktop = ({
         ? fullReplies
         : previewReplies
       : getPreviewDisplayReplies(previewReplies, BOARD_REPLIES_PREVIEW_VISIBLE_COUNT);
-  const freshRepliesForRender = useFreshReplies(repliesForRender);
+  const freshRepliesForRender = useFreshReplies(repliesForRender, { post: resolvedPost });
   useRegisterFreshReplies(resolvedPost, freshRepliesForRender);
   const setResetFunction = useFeedResetStore((s) => s.setResetFunction);
   const repliesResetRequestId = useThreadLiveUpdatesStore((state) => state.repliesResetRequestId);

--- a/src/components/post-mobile/post-mobile.tsx
+++ b/src/components/post-mobile/post-mobile.tsx
@@ -676,7 +676,7 @@ const PostMobile = ({
   const { replies, hasMore, loadMore } = repliesResult;
   const updatedReplies = repliesResult.updatedReplies;
   const repliesForRender = updatedReplies?.length ? updatedReplies : replies || [];
-  const freshRepliesForRender = useFreshReplies(repliesForRender);
+  const freshRepliesForRender = useFreshReplies(repliesForRender, { post: resolvedPost });
   useRegisterFreshReplies(resolvedPost, freshRepliesForRender);
   const reset = (repliesResult as { reset?: () => Promise<void> }).reset;
   const setResetFunction = useFeedResetStore((s) => s.setResetFunction);

--- a/src/hooks/__tests__/use-fresh-replies.test.tsx
+++ b/src/hooks/__tests__/use-fresh-replies.test.tsx
@@ -12,13 +12,16 @@ type TestComment = {
   content?: string;
   index?: number;
   number?: number;
+  parentCid?: string;
   pendingApproval?: boolean;
+  postCid?: string;
   communityAddress?: string;
 };
 
 const testState = vi.hoisted(() => ({
   accountComments: [] as TestComment[],
   accountCommentsCalls: [] as Array<{ commentIndices?: number[]; filter?: (comment: TestComment) => boolean } | undefined>,
+  post: undefined as TestComment | undefined,
   replies: [] as TestComment[],
 }));
 
@@ -46,7 +49,7 @@ let latestValue: ReturnType<typeof useFreshReplies>;
 let root: Root;
 
 const HookHarness = () => {
-  latestValue = useFreshReplies(testState.replies as never);
+  latestValue = useFreshReplies(testState.replies as never, { post: testState.post as never });
   return null;
 };
 
@@ -60,6 +63,7 @@ describe('useFreshReplies', () => {
   beforeEach(() => {
     testState.accountComments = [];
     testState.accountCommentsCalls = [];
+    testState.post = undefined;
     testState.replies = [];
 
     container = document.createElement('div');
@@ -236,5 +240,69 @@ describe('useFreshReplies', () => {
     renderHook();
 
     expect(latestValue.map((reply) => reply.cid)).toEqual(['reply-8', 'reply-11', 'reply-12']);
+  });
+
+  it('does not replace a failed reply placeholder with a same-index post from another thread', () => {
+    testState.post = {
+      cid: 'g-thread-cid',
+      communityAddress: 'technology.eth',
+    };
+    testState.replies = [
+      {
+        content: 'failed g reply',
+        index: 4,
+        parentCid: 'g-thread-cid',
+        postCid: 'g-thread-cid',
+        communityAddress: 'technology.eth',
+      },
+    ];
+    testState.accountComments = [
+      {
+        cid: 'mu-thread-cid',
+        content: 'mu op',
+        index: 4,
+        postCid: 'mu-thread-cid',
+        communityAddress: 'music.eth',
+      },
+    ];
+
+    renderHook();
+
+    expect(latestValue).toHaveLength(1);
+    expect(latestValue[0]).toBe(testState.replies[0] as never);
+    expect(latestValue[0]?.content).toBe('failed g reply');
+    expect(testState.accountCommentsCalls).toContainEqual({ commentIndices: [4] });
+  });
+
+  it('replaces indexed replies when the account comment still belongs to the same thread', () => {
+    testState.post = {
+      cid: 'thread-cid',
+      communityAddress: 'music.eth',
+    };
+    testState.replies = [
+      {
+        content: 'pending reply',
+        index: 5,
+        parentCid: 'thread-cid',
+        postCid: 'thread-cid',
+        communityAddress: 'music.eth',
+      },
+    ];
+    testState.accountComments = [
+      {
+        cid: 'reply-cid',
+        content: 'fresh reply',
+        index: 5,
+        number: 9,
+        parentCid: 'thread-cid',
+        postCid: 'thread-cid',
+        communityAddress: 'music.bso',
+      },
+    ];
+
+    renderHook();
+
+    expect(latestValue[0]).toBe(testState.accountComments[0] as never);
+    expect(latestValue[0]?.number).toBe(9);
   });
 });

--- a/src/hooks/use-fresh-replies.ts
+++ b/src/hooks/use-fresh-replies.ts
@@ -1,11 +1,55 @@
 import { useMemo } from 'react';
 import { Comment, useAccountComments } from '@bitsocial/bitsocial-react-hooks';
 import { sortRepliesForDisplay } from '../lib/utils/replies-preview-utils';
+import { getCommentCommunityAddress } from '../lib/utils/comment-utils';
+import { normalizeBoardAddress } from '../lib/utils/directory-list-lookup-utils';
 
 // Keep the hook on its indexed fast path when there are no reply indices to resolve.
 const EMPTY_ACCOUNT_COMMENT_LOOKUP = { commentIndices: [-1] };
 
-const useFreshReplies = (replies: Comment[] = []) => {
+type UseFreshRepliesOptions = {
+  post?: Comment;
+};
+
+const getString = (value: unknown): string | undefined => (typeof value === 'string' && value.length > 0 ? value : undefined);
+
+const getThreadPostCid = (post: Comment | undefined): string | undefined => getString(post?.postCid) ?? getString(post?.cid);
+
+const hasSameCommunityAddress = (a: string | undefined, b: string | undefined): boolean => {
+  if (!a || !b) return a === b;
+  return normalizeBoardAddress(a) === normalizeBoardAddress(b);
+};
+
+const isFreshReplyForOriginalReply = (reply: Comment, freshReply: Comment, post: Comment | undefined): boolean => {
+  const replyCid = getString(reply?.cid);
+  const freshReplyCid = getString(freshReply?.cid);
+  if (replyCid && reply?.pendingApproval !== true && replyCid !== freshReplyCid) {
+    return false;
+  }
+
+  const expectedPostCid = getString(reply?.postCid) ?? getThreadPostCid(post);
+  if (expectedPostCid) {
+    if (getString(freshReply?.postCid) !== expectedPostCid) {
+      return false;
+    }
+
+    if (!getString(freshReply?.parentCid)) {
+      return false;
+    }
+  }
+
+  const expectedParentCid = getString(reply?.parentCid);
+  if (expectedParentCid && getString(freshReply?.parentCid) !== expectedParentCid) {
+    return false;
+  }
+
+  const expectedCommunityAddress = getCommentCommunityAddress(reply) ?? getCommentCommunityAddress(post);
+  const freshCommunityAddress = getCommentCommunityAddress(freshReply);
+  return hasSameCommunityAddress(expectedCommunityAddress, freshCommunityAddress);
+};
+
+const useFreshReplies = (replies: Comment[] = [], options: UseFreshRepliesOptions = {}) => {
+  const { post } = options;
   const replyIndices = useMemo(
     () => Array.from(new Set(replies.map((reply) => reply?.index).filter((replyIndex): replyIndex is number => typeof replyIndex === 'number'))),
     [replies],
@@ -74,6 +118,10 @@ const useFreshReplies = (replies: Comment[] = []) => {
         return reply;
       }
 
+      if (!isFreshReplyForOriginalReply(reply, freshReply, post)) {
+        return reply;
+      }
+
       hasFreshReplies = true;
       return freshReply;
     });
@@ -99,7 +147,7 @@ const useFreshReplies = (replies: Comment[] = []) => {
     });
 
     return sortRepliesForDisplay(hasDuplicateReplyIndices ? dedupedReplies : nextReplies);
-  }, [accountCommentsByCidList, accountCommentsByIndexList, replies]);
+  }, [accountCommentsByCidList, accountCommentsByIndexList, post, replies]);
 };
 
 export default useFreshReplies;


### PR DESCRIPTION
## Summary
- keep useFreshReplies from replacing indexed reply placeholders with account comments from a different thread or board
- pass the current thread into desktop and mobile reply rendering so freshness checks can validate thread identity
- add regression coverage for a failed reply placeholder sharing an account-comment index with an OP from another board

## Verification
- corepack yarn build
- corepack yarn lint
- corepack yarn type-check
- corepack yarn test
- corepack yarn doctor --diff
- Browser smoke: /all and /g in Chrome, Firefox, and WebKit; mobile /all in all three engines

Note: full yarn doctor still reports existing aggregate repo findings, but the diff-scoped doctor check found no issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes indexed reply refresh logic on thread views; scope is narrow and covered by new tests, but wrong matching would show incorrect reply content.
> 
> **Overview**
> Fixes a bug where **indexed reply placeholders** (e.g. failed publishes) could be swapped for **account comments from another thread** when they shared the same comment index.
> 
> `useFreshReplies` now takes an optional **`post`** (thread OP) and, before replacing by index, checks **`isFreshReplyForOriginalReply`**: matching `postCid`, `parentCid`, and normalized board/community address. **Desktop and mobile** post views pass `resolvedPost` into the hook.
> 
> Regression tests cover a same-index OP on another board (placeholder kept) and a same-thread pending reply (still upgraded to the fresh account comment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747c227cdb6ac0119c49b0163b39968398defcbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reply freshness validation to ensure comments are correctly matched to their original thread context, preventing mismatched replacements across different conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->