### PR TITLE
fix(catalog): use search hashes for board routes

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -449,6 +449,14 @@ describe('App', () => {
     expect(latestHash).toBe('#s=test');
   });
 
+  it('redirects unknown board settings subpaths to catalog search settings hashes', async () => {
+    await renderApp('/mu/test/settings');
+
+    expect(latestLocation).toBe('/mu/catalog/settings');
+    expect(latestHash).toBe('#s=test');
+    expect(container.querySelector('[data-testid="settings-modal"]')).toBeTruthy();
+  });
+
   it('redirects flash board catalog routes to not-found', async () => {
     testState.directories = [
       { address: 'music-posting.eth', title: '/mu/ - Music', nsfw: false },

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -278,6 +278,7 @@ vi.mock('../components/reply-modal', () => ({
   default: ({ parentCid, postCid }: { parentCid: string; postCid: string }) => createElement('div', { 'data-testid': 'reply-modal' }, `${parentCid}:${postCid}`),
 }));
 
+let latestHash = '';
 let latestLocation = '';
 let container: HTMLDivElement;
 let root: Root;
@@ -287,7 +288,8 @@ const LocationProbe = () => {
   const location = useLocation();
   React.useLayoutEffect(() => {
     latestLocation = `${location.pathname}${location.search}`;
-  }, [location.pathname, location.search]);
+    latestHash = location.hash;
+  }, [location.hash, location.pathname, location.search]);
   return null;
 };
 
@@ -304,6 +306,7 @@ const renderApp = async (initialEntry: string) => {
     App = (await import('../app')).default;
   }
 
+  latestHash = '';
   latestLocation = initialEntry;
   act(() => {
     root.render(createElement(MemoryRouter, { initialEntries: [initialEntry] }, createElement(App!), createElement(LocationProbe)));
@@ -350,6 +353,7 @@ describe('App', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    latestHash = '';
     latestLocation = '';
     testState.account = { author: { address: '0x123' } };
     testState.accountComments = {};
@@ -438,6 +442,13 @@ describe('App', () => {
     expect(container.querySelector('[data-testid="not-found-view"]')).toBeTruthy();
   });
 
+  it('redirects unknown board subpaths to catalog search hashes', async () => {
+    await renderApp('/mu/test');
+
+    expect(latestLocation).toBe('/mu/catalog');
+    expect(latestHash).toBe('#s=test');
+  });
+
   it('redirects flash board catalog routes to not-found', async () => {
     testState.directories = [
       { address: 'music-posting.eth', title: '/mu/ - Music', nsfw: false },
@@ -479,6 +490,13 @@ describe('App', () => {
 
     expect(latestLocation).toBe('/mu/thread/comment-1?focus=1');
     expect(container.querySelector('[data-testid="post-view"]')).toBeTruthy();
+  });
+
+  it('canonicalizes board address catalog routes while preserving search hashes', async () => {
+    await renderApp('/music-posting.eth/catalog#s=test');
+
+    expect(latestLocation).toBe('/mu/catalog');
+    expect(latestHash).toBe('#s=test');
   });
 
   it('canonicalizes a direct route for the current resolved directory board', async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -120,7 +120,7 @@ const BoardLayout = () => {
   }
 
   if (boardIdentifier && pageNumber && !isBoardFeedPageNumber(pageNumber)) {
-    return <Navigate to={getCatalogSearchRoute(boardIdentifier, pageNumber, search)} replace />;
+    return <Navigate to={getCatalogSearchRoute(boardIdentifier, pageNumber, search, { settings: pathname.endsWith('/settings') })} replace />;
   }
 
   if (isCatalogView(pathname, params) && isFlashBoardRoute(boardIdentifier, directories)) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,6 +32,8 @@ import {
   isValidBoardModRoute,
   isValidModRoute,
   isFlashBoardRoute,
+  isBoardFeedPageNumber,
+  getCatalogSearchRoute,
 } from './lib/utils/route-utils';
 import styles from './app.module.css';
 import { DesktopBoardButtons, MobileAllFeedFilter, MobileBoardButtons } from './components/board-buttons/board-buttons';
@@ -75,7 +77,7 @@ const getPostFormRouteKeyPath = (pathname: string) => pathname.replace(/\/settin
 const BoardLayout = () => {
   const params = useParams();
   const { accountCommentIndex, boardIdentifier, pageNumber } = params;
-  const { pathname, search } = useLocation();
+  const { pathname, search, hash } = useLocation();
   const isMobile = useIsMobile();
   const isInAllView = isAllView(pathname);
   const isInSubscriptionsView = isSubscriptionsView(pathname, useParams());
@@ -117,6 +119,10 @@ const BoardLayout = () => {
     return <Navigate to='/not-found' replace />;
   }
 
+  if (boardIdentifier && pageNumber && !isBoardFeedPageNumber(pageNumber)) {
+    return <Navigate to={getCatalogSearchRoute(boardIdentifier, pageNumber, search)} replace />;
+  }
+
   if (isCatalogView(pathname, params) && isFlashBoardRoute(boardIdentifier, directories)) {
     return <Navigate to='/not-found' replace />;
   }
@@ -140,7 +146,7 @@ const BoardLayout = () => {
     const canonicalBoardIdentifier = resolvedDirectoryBoardPath ?? (isDirectoryCandidate ? boardIdentifier : getBoardPath(boardIdentifier, directories));
     if (canonicalBoardIdentifier !== boardIdentifier) {
       const canonicalPath = pathname.replace(`/${boardIdentifier}`, `/${canonicalBoardIdentifier}`);
-      return <Navigate to={canonicalPath + (search || '')} replace />;
+      return <Navigate to={canonicalPath + (search || '') + (hash || '')} replace />;
     }
   }
 

--- a/src/components/catalog-search/__tests__/catalog-search.test.tsx
+++ b/src/components/catalog-search/__tests__/catalog-search.test.tsx
@@ -12,6 +12,7 @@ const testState = vi.hoisted(() => ({
   debounceCancelMock: vi.fn(),
   isMobile: false,
   location: {
+    hash: '',
     pathname: '/mu/catalog',
     search: '',
   },
@@ -92,6 +93,7 @@ describe('CatalogSearch', () => {
     testState.debounceCancelMock.mockReset();
     testState.isMobile = false;
     testState.location = {
+      hash: '',
       pathname: '/mu/catalog',
       search: '',
     };
@@ -108,10 +110,11 @@ describe('CatalogSearch', () => {
     container.remove();
   });
 
-  it('opens from the query param and seeds the catalog search filter', async () => {
+  it('opens from the search hash and seeds the catalog search filter', async () => {
     testState.location = {
+      hash: '#s=linux',
       pathname: '/mu/catalog',
-      search: '?q=linux',
+      search: '',
     };
 
     await renderSearch();
@@ -121,15 +124,43 @@ describe('CatalogSearch', () => {
     expect(queryInput()?.getAttribute('value')).toBe('linux');
   });
 
-  it('clears the catalog search filter when navigation removes the query param', async () => {
+  it('migrates the legacy query param to the search hash', async () => {
     testState.location = {
+      hash: '',
       pathname: '/mu/catalog',
       search: '?q=linux',
     };
 
     await renderSearch();
 
+    expect(testState.setSearchFilterMock).toHaveBeenCalledWith('linux');
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu/catalog#s=linux', { replace: true });
+  });
+
+  it('prefers the search hash when stripping a legacy query param', async () => {
     testState.location = {
+      hash: '#s=hash-value',
+      pathname: '/mu/catalog',
+      search: '?t=1w&q=query-value',
+    };
+
+    await renderSearch();
+
+    expect(testState.setSearchFilterMock).toHaveBeenCalledWith('hash-value');
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu/catalog?t=1w#s=hash-value', { replace: true });
+  });
+
+  it('clears the catalog search filter when navigation removes the search hash', async () => {
+    testState.location = {
+      hash: '#s=linux',
+      pathname: '/mu/catalog',
+      search: '',
+    };
+
+    await renderSearch();
+
+    testState.location = {
+      hash: '',
       pathname: '/mu/catalog',
       search: '',
     };
@@ -154,7 +185,7 @@ describe('CatalogSearch', () => {
     await dispatchInput(input, 'web3');
 
     expect(testState.setSearchFilterMock).toHaveBeenCalledWith('web3');
-    expect(testState.navigateMock).toHaveBeenCalledWith('/mu/catalog?q=web3', { replace: true });
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu/catalog#s=web3', { replace: true });
 
     await act(async () => {
       input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));

--- a/src/components/catalog-search/catalog-search.tsx
+++ b/src/components/catalog-search/catalog-search.tsx
@@ -5,33 +5,44 @@ import styles from './catalog-search.module.css';
 import useIsMobile from '../../hooks/use-is-mobile';
 import useCatalogFiltersStore from '../../stores/use-catalog-filters-store';
 import debounce from 'lodash/debounce';
+import { getCatalogSearchHash } from '../../lib/utils/route-utils';
 
 const CatalogSearch = () => {
   const { t } = useTranslation();
-  const { pathname, search } = useLocation();
+  const { pathname, search, hash } = useLocation();
   const navigate = useNavigate();
   const [searchState, setSearchState] = useState({ open: false, value: '' });
   const { setSearchFilter, clearSearchFilter } = useCatalogFiltersStore();
-  const queryParam = new URLSearchParams(search).get('q') ?? '';
-  const openSearch = !!queryParam || searchState.open;
-  const inputValue = searchState.open || searchState.value ? searchState.value : queryParam;
+  const legacyQueryParam = new URLSearchParams(search).get('q') ?? '';
+  const hashSearchParam = new URLSearchParams(hash.replace(/^#/, '')).get('s') ?? '';
+  const catalogSearchParam = hashSearchParam || legacyQueryParam;
+  const openSearch = !!catalogSearchParam || searchState.open;
+  const inputValue = searchState.open || searchState.value ? searchState.value : catalogSearchParam;
 
   useEffect(() => {
-    if (queryParam) {
-      setSearchFilter(queryParam);
+    if (legacyQueryParam) {
+      const urlParams = new URLSearchParams(search);
+      urlParams.delete('q');
+      const newSearch = urlParams.toString();
+      navigate(`${pathname}${newSearch ? `?${newSearch}` : ''}${getCatalogSearchHash(catalogSearchParam)}`, { replace: true });
+    }
+
+    if (catalogSearchParam) {
+      setSearchFilter(catalogSearchParam);
       return;
     }
 
     clearSearchFilter();
-  }, [queryParam, setSearchFilter, clearSearchFilter]);
+  }, [catalogSearchParam, clearSearchFilter, legacyQueryParam, navigate, pathname, search, setSearchFilter]);
 
   const updateURL = useCallback(
     (searchText: string) => {
       const urlParams = new URLSearchParams(search);
+      urlParams.delete('q');
       if (searchText.trim()) {
-        urlParams.set('q', searchText);
-      } else {
-        urlParams.delete('q');
+        const newSearch = urlParams.toString();
+        navigate(`${pathname}${newSearch ? `?${newSearch}` : ''}${getCatalogSearchHash(searchText)}`, { replace: true });
+        return;
       }
       const newSearch = urlParams.toString();
       const newPath = pathname + (newSearch ? `?${newSearch}` : '');

--- a/src/components/markdown/__tests__/markdown.test.tsx
+++ b/src/components/markdown/__tests__/markdown.test.tsx
@@ -349,15 +349,20 @@ describe('Markdown', () => {
     expect(container.textContent).toBe('see >>>/fit/, next');
   });
 
-  it('renders board search paths as catalog search hash links', async () => {
+  it.each([
+    ['>>>/biz/test', '/biz/catalog#s=test'],
+    ['>>>/biz/test-term', '/biz/catalog#s=test-term'],
+    ['>>>/biz/test_term', '/biz/catalog#s=test_term'],
+    ['>>>/board.eth/test', '/board.eth/catalog#s=test'],
+  ])('renders board search path %s as a catalog search hash link', async (quoteLink, href) => {
     await renderMarkdown({
-      content: 'see >>>/biz/test.',
+      content: `see ${quoteLink}.`,
     });
 
     const link = container.querySelector('a');
-    expect(link?.getAttribute('href')).toBe('/biz/catalog#s=test');
-    expect(link?.textContent).toBe('>>>/biz/test');
-    expect(container.textContent).toBe('see >>>/biz/test.');
+    expect(link?.getAttribute('href')).toBe(href);
+    expect(link?.textContent).toBe(quoteLink);
+    expect(container.textContent).toBe(`see ${quoteLink}.`);
   });
 
   it('normalizes hash-routed 5chan links before passing them to React Router', async () => {

--- a/src/components/markdown/__tests__/markdown.test.tsx
+++ b/src/components/markdown/__tests__/markdown.test.tsx
@@ -349,6 +349,17 @@ describe('Markdown', () => {
     expect(container.textContent).toBe('see >>>/fit/, next');
   });
 
+  it('renders board search paths as catalog search hash links', async () => {
+    await renderMarkdown({
+      content: 'see >>>/biz/test.',
+    });
+
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('/biz/catalog#s=test');
+    expect(link?.textContent).toBe('>>>/biz/test');
+    expect(container.textContent).toBe('see >>>/biz/test.');
+  });
+
   it('normalizes hash-routed 5chan links before passing them to React Router', async () => {
     testState.internalPathByHref = {
       'https://5chan.local/#/mu': '#/mu',

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -842,7 +842,9 @@ const Markdown = ({ content, title, postCid, communityAddress, parseSpoilers = t
           return;
         }
         if (!segment.value) return;
-        elements.push(<React.Fragment key={`text-${segment.start}`}>{renderTextLines(normalizeContent(segment.value), context, `${segment.start}:`)}</React.Fragment>);
+        elements.push(
+          <React.Fragment key={`text-${segment.start}`}>{renderTextLines(normalizeContent(segment.value), context, `${segment.start}:`)}</React.Fragment>,
+        );
       });
       return elements;
     }

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -21,6 +21,7 @@ import ReplyQuotePreview from '../reply-quote-preview/reply-quote-preview';
 import ExternalNumberQuoteLink from './external-number-quote-link';
 import { findDirectoryByAddress, useDirectories, type DirectoryCommunity } from '../../hooks/use-directories';
 import { getDirectoryCodeForBoardAddress } from '../../lib/utils/directory-list-lookup-utils';
+import { getCatalogSearchRoute } from '../../lib/utils/route-utils';
 import {
   createDiceRollMarkupRegex,
   createFortuneBbcodeRegex,
@@ -163,7 +164,7 @@ type Token =
 
 const SPOILER_REGEX = /\[[sS][pP][oO][iI][lL][eE][rR]\]([\s\S]*?)\[\/[sS][pP][oO][iI][lL][eE][rR]\]/;
 const MARKDOWN_LINK_REGEX = /(?<!!)\[([^\]\n]+)\]\(\s*([^\n)]*?)\s*\)/;
-const CROSSBOARD_REGEX = />>>\/((?:[a-zA-Z0-9]{1,10}\/(?:[a-zA-Z0-9]{46})?|[a-zA-Z0-9\-.]+(?:\/[a-zA-Z0-9]{46})?))[.,:;!?]*/;
+const CROSSBOARD_REGEX = />>>\/((?:[a-zA-Z0-9]{1,10}\/(?:[a-zA-Z0-9]{46}|[a-zA-Z0-9_-]+)?|[a-zA-Z0-9\-.]+(?:\/(?:[a-zA-Z0-9]{46}|[a-zA-Z0-9_-]+))?))[.,:;!?]*/;
 const QUOTE_LINK_REGEX = /(?<![>/\w])>>(\d+)(?![\d/])/;
 const URL_REGEX = /https?:\/\/[^\s<>[\]]+/;
 type QstBbcodeTag = 'b' | 'i' | 'red' | 'green' | 'blue';
@@ -283,9 +284,17 @@ function getCrossboardRoute(fullPattern: string): string | null {
     const [code, cid] = pathPart.split('/');
     return `/${code}/thread/${cid}`;
   }
+  if (/^[a-zA-Z0-9]{1,10}\/[a-zA-Z0-9_-]+$/.test(pathPart)) {
+    const [code, searchText] = pathPart.split('/');
+    return getCatalogSearchRoute(code, searchText);
+  }
   if (/^[^/]+\/[a-zA-Z0-9]{46}$/.test(pathPart)) {
     const [address, cid] = pathPart.split('/');
     return `/${address}/thread/${cid}`;
+  }
+  if (/^[^/]+\/[a-zA-Z0-9_-]+$/.test(pathPart)) {
+    const [address, searchText] = pathPart.split('/');
+    return getCatalogSearchRoute(address, searchText);
   }
   return `/${pathPart}`;
 }
@@ -833,9 +842,7 @@ const Markdown = ({ content, title, postCid, communityAddress, parseSpoilers = t
           return;
         }
         if (!segment.value) return;
-        elements.push(
-          <React.Fragment key={`text-${segment.start}`}>{renderTextLines(normalizeContent(segment.value), context, `${segment.start}:`)}</React.Fragment>,
-        );
+        elements.push(<React.Fragment key={`text-${segment.start}`}>{renderTextLines(normalizeContent(segment.value), context, `${segment.start}:`)}</React.Fragment>);
       });
       return elements;
     }

--- a/src/lib/utils/__tests__/route-utils.test.ts
+++ b/src/lib/utils/__tests__/route-utils.test.ts
@@ -217,6 +217,8 @@ describe('catalog search route helpers', () => {
     expect(getCatalogSearchRoute('biz', 'test')).toBe('/biz/catalog#s=test');
     expect(getCatalogSearchRoute('biz', 'test', '', { settings: true })).toBe('/biz/catalog/settings#s=test');
     expect(getCatalogSearchRoute('biz', 'cats and dogs', '?t=1w')).toBe('/biz/catalog?t=1w#s=cats%20and%20dogs');
+    expect(getCatalogSearchHash('   ')).toBe('');
+    expect(getCatalogSearchRoute('biz', '')).toBe('/biz/catalog');
   });
 });
 

--- a/src/lib/utils/__tests__/route-utils.test.ts
+++ b/src/lib/utils/__tests__/route-utils.test.ts
@@ -3,6 +3,8 @@ import {
   areSameBoardAddress,
   extractDirectoryFromTitle,
   getBoardPath,
+  getCatalogSearchHash,
+  getCatalogSearchRoute,
   getFeedCacheKey,
   getFeedType,
   getPageFromFeedPath,
@@ -206,6 +208,14 @@ describe('feed pagination helpers', () => {
     expect(getPageFromFeedPath('/biz/catalog/4/settings')).toBe(4);
     expect(getPageFromFeedPath('/biz/11')).toBe(1);
     expect(getPageFromFeedPath('/biz')).toBe(1);
+  });
+});
+
+describe('catalog search route helpers', () => {
+  it('formats catalog search routes with 4chan-style hash params', () => {
+    expect(getCatalogSearchHash('test')).toBe('#s=test');
+    expect(getCatalogSearchRoute('biz', 'test')).toBe('/biz/catalog#s=test');
+    expect(getCatalogSearchRoute('biz', 'cats and dogs', '?t=1w')).toBe('/biz/catalog?t=1w#s=cats%20and%20dogs');
   });
 });
 

--- a/src/lib/utils/__tests__/route-utils.test.ts
+++ b/src/lib/utils/__tests__/route-utils.test.ts
@@ -215,6 +215,7 @@ describe('catalog search route helpers', () => {
   it('formats catalog search routes with 4chan-style hash params', () => {
     expect(getCatalogSearchHash('test')).toBe('#s=test');
     expect(getCatalogSearchRoute('biz', 'test')).toBe('/biz/catalog#s=test');
+    expect(getCatalogSearchRoute('biz', 'test', '', { settings: true })).toBe('/biz/catalog/settings#s=test');
     expect(getCatalogSearchRoute('biz', 'cats and dogs', '?t=1w')).toBe('/biz/catalog?t=1w#s=cats%20and%20dogs');
   });
 });

--- a/src/lib/utils/__tests__/url-utils.test.ts
+++ b/src/lib/utils/__tests__/url-utils.test.ts
@@ -107,10 +107,12 @@ describe('url-utils', () => {
     expect(isValidCrossboardPattern('>>>/biz/')).toBe(true);
     expect(isValidCrossboardPattern(`>>>/biz/${'a'.repeat(46)}`)).toBe(true);
     expect(isValidCrossboardPattern('>>>/biz/123')).toBe(true);
+    expect(isValidCrossboardPattern('>>>/biz/test')).toBe(true);
     expect(isValidCrossboardPattern(`>>>/board.eth/${'b'.repeat(46)}`)).toBe(true);
     expect(isValidCrossboardPattern('>>>/board.eth/123')).toBe(true);
+    expect(isValidCrossboardPattern('>>>/board.eth/test')).toBe(true);
     expect(isValidCrossboardPattern(`>>>/${ipnsKey}`)).toBe(true);
-    expect(isValidCrossboardPattern('>>>/invalid/thread-with-short-cid')).toBe(false);
+    expect(isValidCrossboardPattern('>>>/invalid/thread/extra')).toBe(false);
     expect(isValidCrossboardPattern('>>/biz/')).toBe(false);
   });
 });

--- a/src/lib/utils/__tests__/url-utils.test.ts
+++ b/src/lib/utils/__tests__/url-utils.test.ts
@@ -112,6 +112,7 @@ describe('url-utils', () => {
     expect(isValidCrossboardPattern('>>>/board.eth/123')).toBe(true);
     expect(isValidCrossboardPattern('>>>/board.eth/test')).toBe(true);
     expect(isValidCrossboardPattern(`>>>/${ipnsKey}`)).toBe(true);
+    expect(isValidCrossboardPattern(`>>>/${ipnsKey}/test`)).toBe(true);
     expect(isValidCrossboardPattern('>>>/invalid/thread/extra')).toBe(false);
     expect(isValidCrossboardPattern('>>/biz/')).toBe(false);
   });

--- a/src/lib/utils/route-utils.ts
+++ b/src/lib/utils/route-utils.ts
@@ -225,8 +225,8 @@ export const getCatalogSearchHash = (searchText: string): string => {
   return trimmedSearchText ? `#s=${encodeURIComponent(trimmedSearchText)}` : '';
 };
 
-export const getCatalogSearchRoute = (boardIdentifier: string, searchText: string, search = ''): string =>
-  `/${boardIdentifier}/catalog${search}${getCatalogSearchHash(searchText)}`;
+export const getCatalogSearchRoute = (boardIdentifier: string, searchText: string, search = '', options?: { settings?: boolean }): string =>
+  `/${boardIdentifier}/catalog${options?.settings ? '/settings' : ''}${search}${getCatalogSearchHash(searchText)}`;
 
 /** Internal: check if segment is a multiboard root (all, subs, mod) */
 function isMultiboardRoot(segment: string): boolean {

--- a/src/lib/utils/route-utils.ts
+++ b/src/lib/utils/route-utils.ts
@@ -215,10 +215,18 @@ export const isValidBoardModRoute = (pathname: string): boolean => {
   return VALID_BOARD_MOD_SUBPATHS.includes(subpath);
 };
 
-/** Page numbers 1–10 for board feed pagination */
+/** Page numbers 1-10 for board feed pagination */
 const BOARD_PAGE_REGEX = /^([1-9]|10)$/;
 
-const isBoardFeedPageNumber = (segment: string): boolean => BOARD_PAGE_REGEX.test(segment);
+export const isBoardFeedPageNumber = (segment: string): boolean => BOARD_PAGE_REGEX.test(segment);
+
+export const getCatalogSearchHash = (searchText: string): string => {
+  const trimmedSearchText = searchText.trim();
+  return trimmedSearchText ? `#s=${encodeURIComponent(trimmedSearchText)}` : '';
+};
+
+export const getCatalogSearchRoute = (boardIdentifier: string, searchText: string, search = ''): string =>
+  `/${boardIdentifier}/catalog${search}${getCatalogSearchHash(searchText)}`;
 
 /** Internal: check if segment is a multiboard root (all, subs, mod) */
 function isMultiboardRoot(segment: string): boolean {

--- a/src/lib/utils/url-utils.ts
+++ b/src/lib/utils/url-utils.ts
@@ -296,6 +296,12 @@ export const isValidCrossboardPattern = (pattern: string): boolean => {
     return true;
   }
 
+  // Check if it's a directory + catalog search pattern: >>>/biz/test
+  const directoryCatalogSearchMatch = pathPart.match(/^([a-zA-Z0-9]{1,10})\/([a-zA-Z0-9_-]+)$/);
+  if (directoryCatalogSearchMatch) {
+    return true;
+  }
+
   // Check if it's a full address + thread pattern: >>>/board.eth/fullCid
   const addressThreadMatch = pathPart.match(/^([^/]+)\/([a-zA-Z0-9]{46})$/);
   if (addressThreadMatch) {
@@ -308,6 +314,13 @@ export const isValidCrossboardPattern = (pattern: string): boolean => {
   const addressPostNumberMatch = pathPart.match(/^([^/]+)\/(\d+)$/);
   if (addressPostNumberMatch) {
     const [, address] = addressPostNumberMatch;
+    return isValidDomain(address) || isValidIPNSKey(address);
+  }
+
+  // Check if it's a full address + catalog search pattern: >>>/board.eth/test
+  const addressCatalogSearchMatch = pathPart.match(/^([^/]+)\/([a-zA-Z0-9_-]+)$/);
+  if (addressCatalogSearchMatch) {
+    const [, address] = addressCatalogSearchMatch;
     return isValidDomain(address) || isValidIPNSKey(address);
   }
 

--- a/src/views/catalog/__tests__/catalog.test.tsx
+++ b/src/views/catalog/__tests__/catalog.test.tsx
@@ -931,7 +931,7 @@ describe('Catalog', () => {
     testState.searchText = 'asddasd';
     testState.hasMore = false;
 
-    await renderCatalog({ initialEntry: '/mu/catalog?q=asddasd', routePath: '/:boardIdentifier/catalog' });
+    await renderCatalog({ initialEntry: '/mu/catalog#s=asddasd', routePath: '/:boardIdentifier/catalog' });
 
     expect(container.textContent).toContain('nothing_found');
     expect(container.textContent).not.toContain('no_threads');


### PR DESCRIPTION
## Summary
- redirect board search-style routes like `/mu/test` to `/mu/catalog#s=test`
- render `>>>/board/search` cross-board links as catalog search hash links
- migrate legacy catalog `?q=` URLs to `#s=` while preserving other query params

## Verification
- corepack yarn build
- corepack yarn lint
- corepack yarn type-check
- corepack yarn test
- corepack yarn doctor --diff
- playwright-cli route checks in Chrome, Firefox, WebKit, and mobile Chrome

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client routing and URL shape for catalog search; behavior is covered by tests but wrong redirects or migration could break bookmarks and shared links.
> 
> **Overview**
> Catalog search state now lives in URL fragments (`#s=...`) instead of `?q=`, with helpers to build those routes and **automatic migration** from legacy `?q=` while keeping other query params (e.g. time filters).
> 
> **Routing** treats non-pagination board segments (e.g. `/mu/test`, including `/settings`) as catalog searches and redirects to the catalog with the appropriate hash. Board address canonicalization **keeps the search hash** on redirect.
> 
> **Markdown** `>>>/board/search-term` cross-board links resolve to catalog hash URLs; validation and regexes were extended for alphanumeric/underscore search terms (not only CIDs and post numbers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57beac736ab83435d14277befc39b4536a1796f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog searches now use URL fragments (`#s=...`) instead of query parameters, enabling better preservation across links and redirects.
  * Cross-board references and links can now route to search-based catalog views.
* **Bug Fixes**
  * Redirects and canonicalization now preserve the search fragment and migrate legacy search URLs (`?q=...`) to fragment format.
  * Invalid board feed page numbers route users to the appropriate catalog search view.
* **Tests**
  * Expanded coverage for hash-based navigation, redirect/canonicalization behavior, and updated link parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->