### PR TITLE
chore(deps): upgrade bitsocial-react-hooks to 0.1.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@bbob/parser": "4.3.1",
-    "@bitsocial/bitsocial-react-hooks": "0.1.31",
+    "@bitsocial/bitsocial-react-hooks": "0.1.32",
     "@bitsocial/bso-resolver": "0.0.10",
     "@capacitor/app": "7.0.1",
     "@capacitor/browser": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "5chan@workspace:."
   dependencies:
     "@bbob/parser": "npm:4.3.1"
-    "@bitsocial/bitsocial-react-hooks": "npm:0.1.31"
+    "@bitsocial/bitsocial-react-hooks": "npm:0.1.32"
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@capacitor/android": "npm:7.4.5"
     "@capacitor/app": "npm:7.0.1"
@@ -1581,9 +1581,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bitsocial-react-hooks@npm:0.1.31":
-  version: 0.1.31
-  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.31"
+"@bitsocial/bitsocial-react-hooks@npm:0.1.32":
+  version: 0.1.32
+  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.32"
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@pkcprotocol/pkc-js": "npm:0.0.72"
@@ -1602,7 +1602,7 @@ __metadata:
     zustand: "npm:4.5.7"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/3bb68ebca7008dde97a93b04f745e427dc57a8eabaeeddff00bc3517fae34873d2b8e747311f2e4a3bc0b131955a1afb9f9a86f8d2c693260aebe6d0234b03ba
+  checksum: 10c0/b2eb17e3c12dc666d8ee92aed5dfdf5df8fa7b1e108fa467aa29b4e0f54fa7ba6790906cfb8e619d9813bc488036449a6a7e9b6cee326701701889ba75e2361a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `@bitsocial/bitsocial-react-hooks` from 0.1.31 to 0.1.32
- consume the upstream reply propagation fix from bitsocial-react-hooks#78
- keep the dependency pinned to the published npm package with no local link

## Why

Newly published replies could disappear from a thread while an account comment was propagating, and a hard refresh could temporarily remove all replies. The upstream fix keeps published account replies visible unless they are explicitly marked as purged and refreshes reply feeds when purge state changes.

Upstream release: https://github.com/bitsocialnet/bitsocial-react-hooks/releases/tag/v0.1.32

## Verification

- `corepack yarn install`
- `corepack yarn why @bitsocial/bitsocial-react-hooks`
- `corepack yarn knip`
- `corepack yarn test` — 165 files, 1,359 tests passed
- `corepack yarn build`
- `corepack yarn lint` — 0 warnings, 0 errors
- `corepack yarn type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core data layer for threads and replies across the app; risk is mitigated by a patch bump and reported full test/build/lint verification, but reply-feed behavior is user-visible if the upstream fix regresses.
> 
> **Overview**
> Bumps **`@bitsocial/bitsocial-react-hooks`** from **0.1.31** to **0.1.32** in `package.json` and refreshes **`yarn.lock`**. There are **no application source changes** in this repo—the behavior update comes entirely from the published package.
> 
> The upstream release addresses **reply visibility during account-comment propagation**: replies should no longer vanish from a thread while a comment is still propagating, and a hard refresh should not temporarily strip all replies. Published account replies stay visible unless explicitly purged, and reply feeds refresh when purge state changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661f94ec00c1708b4a513a531f6ad43800a6f4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->