### PR TITLE
fix(publishing): show pending threads immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@bbob/parser": "4.3.1",
-    "@bitsocial/bitsocial-react-hooks": "0.1.33",
+    "@bitsocial/bitsocial-react-hooks": "0.1.34",
     "@bitsocial/bso-resolver": "0.0.10",
     "@capacitor/app": "7.0.1",
     "@capacitor/browser": "7.0.5",

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -3,6 +3,7 @@ import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Link, MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import usePendingPostNavigationStore from '../stores/use-pending-post-navigation-store';
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 const act = (React as { act?: (cb: () => void | Promise<void>) => void | Promise<void> }).act as (cb: () => void | Promise<void>) => void | Promise<void>;
 
@@ -288,16 +289,19 @@ vi.mock('../components/reply-modal', () => ({
 
 let latestHash = '';
 let latestLocation = '';
+let navigateFromTest: ReturnType<typeof useNavigate> | undefined;
 let container: HTMLDivElement;
 let root: Root;
 let App: typeof import('../app').default | null = null;
 
 const LocationProbe = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   React.useLayoutEffect(() => {
     latestLocation = `${location.pathname}${location.search}`;
     latestHash = location.hash;
-  }, [location.hash, location.pathname, location.search]);
+    navigateFromTest = navigate;
+  }, [location.hash, location.pathname, location.search, navigate]);
   return null;
 };
 
@@ -309,13 +313,13 @@ const flushEffects = async (count = 8) => {
   act(() => {});
 };
 
-const renderApp = async (initialEntry: string) => {
+const renderApp = async (initialEntry: string | { pathname: string; state?: unknown }) => {
   if (!App) {
     App = (await import('../app')).default;
   }
 
   latestHash = '';
-  latestLocation = initialEntry;
+  latestLocation = typeof initialEntry === 'string' ? initialEntry : initialEntry.pathname;
   act(() => {
     root.render(createElement(MemoryRouter, { initialEntries: [initialEntry] }, createElement(App!), createElement(LocationProbe)));
   });
@@ -361,8 +365,10 @@ describe('App', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
     latestHash = '';
     latestLocation = '';
+    navigateFromTest = undefined;
     testState.account = { author: { address: '0x123' } };
     testState.accountComments = {};
     testState.accountCommunityAddresses = [];
@@ -403,6 +409,7 @@ describe('App', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
   });
 
   it('renders board layout chrome on multiboard routes', async () => {
@@ -415,6 +422,40 @@ describe('App', () => {
     expect(container.querySelector('[data-testid="desktop-board-buttons"]')).toBeTruthy();
     expect(container.querySelector('[data-testid="board-blotter"]')).toBeTruthy();
     expect(latestLocation).toBe('/all');
+  });
+
+  it('keeps the board chrome and cached feed mounted during the immediate pending handoff', async () => {
+    await renderApp('/mu');
+    const boardsBar = container.querySelector('[data-testid="boards-bar"]');
+    const boardHeader = container.querySelector('[data-testid="board-header"]');
+    const feedCache = container.querySelector('[data-testid="feed-cache-container"]');
+
+    await act(async () => {
+      usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+      navigateFromTest?.('/pending/0', {
+        state: { boardPath: 'mu', pendingPost: { communityAddress: 'music-posting.eth', index: 0 } },
+      });
+    });
+    await flushEffects();
+
+    expect(container.querySelector('[data-testid="pending-post-view"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="boards-bar"]')).toBe(boardsBar);
+    expect(container.querySelector('[data-testid="board-header"]')).toBe(boardHeader);
+    expect(feedCache?.isConnected).toBe(true);
+  });
+
+  it('restores the pending board shell from route state before the account row is addressable', async () => {
+    testState.accountComments = { 0: {} };
+
+    await renderApp({
+      pathname: '/pending/0',
+      state: { pendingPost: { communityAddress: 'music-posting.eth', index: 0 } },
+    });
+
+    expect(container.querySelector('[data-testid="pending-post-view"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="board-header"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="post-form"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="feed-cache-container"]')).toBeTruthy();
   });
 
   it('keeps an open post form and its draft when settings opens from a trailing-slash board route', async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect } from 'react';
+import { Activity, lazy, Suspense, useCallback, useEffect } from 'react';
 import { Navigate, Outlet, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { useAccount, useAccountComment, useCommunity } from '@bitsocial/bitsocial-react-hooks';
 import { initSnow, removeSnow, shouldShowSnow } from './lib/snow';
@@ -7,6 +7,7 @@ import { preloadReplyModal, preloadThemeAssets } from './lib/utils/preload-utils
 import { hasModQueueAccessRole } from './lib/utils/mod-access';
 import useReplyModalStore from './stores/use-reply-modal-store';
 import useCreateBoardModalStore from './stores/use-create-board-modal-store';
+import usePendingPostNavigationStore from './stores/use-pending-post-navigation-store';
 import useSpecialThemeStore from './stores/use-special-theme-store';
 import useIsMobile from './hooks/use-is-mobile';
 import { useAccountCommunityAddresses } from './hooks/use-account-community-addresses';
@@ -19,6 +20,7 @@ import useSuspendOffscreenMediaPlayback from './hooks/use-suspend-offscreen-medi
 import { normalizeAccountCommentIndex } from './lib/utils/account-comment-index-utils';
 import { getCommentCommunityAddress } from './lib/utils/comment-utils';
 import { getPageDraftKey } from './lib/utils/location-draft-utils';
+import { getPendingPostRoutePost } from './lib/utils/pending-post-route-state';
 import {
   getBoardPath,
   isBoardModRoute,
@@ -78,8 +80,9 @@ const getPageOneCanonicalPath = (boardIdentifier: string, pathname: string) => `
 
 const BoardLayout = () => {
   const params = useParams();
+  const isNavigatingToPendingPost = usePendingPostNavigationStore((state) => state.isNavigatingToPendingPost);
   const { accountCommentIndex, boardIdentifier, pageNumber } = params;
-  const { pathname, search, hash } = useLocation();
+  const { pathname, search, hash, state } = useLocation();
   const isMobile = useIsMobile();
   const isInAllView = isAllView(pathname);
   const isInSubscriptionsView = isSubscriptionsView(pathname, useParams());
@@ -88,7 +91,7 @@ const BoardLayout = () => {
   const communityAddress = useResolvedCommunityAddress(boardIdentifier);
   const { boardPath: resolvedDirectoryBoardPath, isDirectoryCandidate } = useResolvedDirectoryBoardPath(boardIdentifier);
   const pendingPost = useAccountComment({ commentIndex: normalizeAccountCommentIndex(accountCommentIndex) });
-  const pendingPostCommunityAddress = getCommentCommunityAddress(pendingPost);
+  const pendingPostCommunityAddress = getCommentCommunityAddress(pendingPost) || getCommentCommunityAddress(getPendingPostRoutePost(state));
   const { closeCreateBoardModal } = useCreateBoardModalStore();
   const isOnPostRoute = isPostRoute(pathname);
   const isOnPendingPostRoute = isPendingPostRoute(pathname);
@@ -193,8 +196,12 @@ const BoardLayout = () => {
               <DesktopBoardButtons />
             </>
           )}
-      {!isOnModQueueRoute && <FeedCacheContainer />}
-      {shouldRenderOutlet && <Outlet />}
+      {!isOnModQueueRoute && (
+        <Activity mode={isNavigatingToPendingPost ? 'hidden' : 'visible'}>
+          <FeedCacheContainer />
+        </Activity>
+      )}
+      {shouldRenderOutlet && <Outlet key='board-layout-outlet' />}
     </div>
   );
 };

--- a/src/components/board-header/__tests__/board-header.test.tsx
+++ b/src/components/board-header/__tests__/board-header.test.tsx
@@ -127,7 +127,7 @@ vi.mock('../../../generated/asset-manifest', () => ({
 let container: HTMLDivElement;
 let root: Root;
 
-const renderHeader = async (initialEntry: string) => {
+const renderHeader = async (initialEntry: string | { pathname: string; state?: unknown }) => {
   await act(async () => {
     root.render(createElement(MemoryRouter, { initialEntries: [initialEntry] }, createElement(BoardHeader)));
   });
@@ -228,6 +228,16 @@ describe('BoardHeader', () => {
 
     expect(container.querySelector('img')?.getAttribute('src')).toBe('banner-a.png');
     expect(mathRandomSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps board metadata while an optimistic pending post is being persisted', async () => {
+    testState.accountComment = undefined;
+    testState.resolvedAddress = undefined;
+
+    await renderHeader({ pathname: '/pending/0', state: { pendingPost: { communityAddress: 'music-posting.eth', index: 0 } } });
+
+    expect(container.textContent).toContain('/mu/ - Music');
+    expect(container.textContent).toContain('music-posting.eth');
   });
 
   it('renders hidden special board metadata without a directory entry', async () => {

--- a/src/components/board-header/board-header.tsx
+++ b/src/components/board-header/board-header.tsx
@@ -13,6 +13,8 @@ import styles from './board-header.module.css';
 import { useDirectories } from '../../hooks/use-directories';
 import { useResolvedCommunityAddress } from '../../hooks/use-resolved-community-address';
 import { normalizeAccountCommentIndex } from '../../lib/utils/account-comment-index-utils';
+import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
+import { getPendingPostRoutePost } from '../../lib/utils/pending-post-route-state';
 import useIsMobile from '../../hooks/use-is-mobile';
 import useIsCommunityOffline from '../../hooks/use-is-community-offline';
 import { shouldShowSnow } from '../../lib/snow';
@@ -58,7 +60,7 @@ const BoardHeader = memo(() => {
   const bannerKey = isInAllView ? 'all' : isInSubscriptionsView ? 'subscriptions' : isInModView ? 'mod' : params.boardIdentifier || 'board';
   const accountComment = useAccountComment({ commentIndex: normalizeAccountCommentIndex(params?.accountCommentIndex) });
   const resolvedAddress = useResolvedCommunityAddress();
-  const communityAddress = resolvedAddress || accountComment?.communityAddress;
+  const communityAddress = resolvedAddress || getCommentCommunityAddress(accountComment) || getCommentCommunityAddress(getPendingPostRoutePost(location.state));
 
   // Use stable community for display fields to avoid rerenders from updatingState
   const stableCommunity = useStableCommunity(communityAddress);

--- a/src/components/boards-bar/__tests__/boards-bar.test.tsx
+++ b/src/components/boards-bar/__tests__/boards-bar.test.tsx
@@ -316,6 +316,17 @@ describe('BoardsBar', () => {
     expect(Array.from(select?.querySelectorAll('option') ?? []).some((option) => option.value === 'mu')).toBe(true);
   });
 
+  it('keeps the mobile board context from pending route state while the account comment loads', async () => {
+    testState.resolvedCommunityAddress = undefined;
+
+    await renderBoardsBar({
+      pathname: '/pending/7',
+      state: { pendingPost: { communityAddress: 'music-posting.eth', index: 7 } },
+    });
+
+    expect(container.querySelector<HTMLSelectElement>('select')?.value).toBe('mu');
+  });
+
   it('preserves pending route state when opening settings', async () => {
     const routeState = {
       boardPath: 'mu',

--- a/src/components/boards-bar/__tests__/boards-bar.test.tsx
+++ b/src/components/boards-bar/__tests__/boards-bar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BoardsBar from '../boards-bar';
 
@@ -128,7 +128,12 @@ const getLinkHref = (text: string) =>
     .find((element) => element.textContent?.trim() === text)
     ?.getAttribute('href');
 
-const renderBoardsBar = async (initialEntry: string) => {
+const LocationStateProbe = () => {
+  const location = useLocation();
+  return createElement('output', { 'data-testid': 'location-state' }, JSON.stringify(location.state));
+};
+
+const renderBoardsBar = async (initialEntry: string | { pathname: string; state?: unknown }) => {
   await act(async () => {
     root.render(
       createElement(
@@ -137,9 +142,12 @@ const renderBoardsBar = async (initialEntry: string) => {
         createElement(
           Routes,
           {},
-          createElement(Route, { path: '/:boardIdentifier/*', element: createElement(BoardsBar) }),
-          createElement(Route, { path: '/pending/:accountCommentIndex/*', element: createElement(BoardsBar) }),
-          createElement(Route, { path: '*', element: createElement(BoardsBar) }),
+          createElement(Route, { path: '/:boardIdentifier/*', element: createElement(React.Fragment, {}, createElement(BoardsBar), createElement(LocationStateProbe)) }),
+          createElement(Route, {
+            path: '/pending/:accountCommentIndex/*',
+            element: createElement(React.Fragment, {}, createElement(BoardsBar), createElement(LocationStateProbe)),
+          }),
+          createElement(Route, { path: '*', element: createElement(React.Fragment, {}, createElement(BoardsBar), createElement(LocationStateProbe)) }),
         ),
       ),
     );
@@ -306,5 +314,20 @@ describe('BoardsBar', () => {
     const select = container.querySelector('select');
     expect(select).toBeTruthy();
     expect(Array.from(select?.querySelectorAll('option') ?? []).some((option) => option.value === 'mu')).toBe(true);
+  });
+
+  it('preserves pending route state when opening settings', async () => {
+    const routeState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 7 },
+    };
+    await renderBoardsBar({ pathname: '/pending/7', state: routeState });
+
+    const settingsLink = Array.from(container.querySelectorAll<HTMLAnchorElement>('a')).find((link) => link.textContent === 'settings');
+    await act(async () => {
+      settingsLink?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.querySelector('[data-testid="location-state"]')?.textContent).toBe(JSON.stringify(routeState));
   });
 });

--- a/src/components/boards-bar/boards-bar.tsx
+++ b/src/components/boards-bar/boards-bar.tsx
@@ -9,6 +9,7 @@ import { useAccountCommunityAddresses } from '../../hooks/use-account-community-
 import { useDirectories, DirectoryCommunity } from '../../hooks/use-directories';
 import { useBoardPath, useResolvedCommunityAddress } from '../../hooks/use-resolved-community-address';
 import { normalizeAccountCommentIndex } from '../../lib/utils/account-comment-index-utils';
+import { getPendingPostRoutePost } from '../../lib/utils/pending-post-route-state';
 import { getBoardPath, extractDirectoryFromTitle } from '../../lib/utils/route-utils';
 import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
 import useCreateBoardModalStore from '../../stores/use-create-board-modal-store';
@@ -429,9 +430,10 @@ BoardsBarMobile.displayName = 'BoardsBarMobile';
 
 const BoardsBar = memo(() => {
   const params = useParams();
+  const location = useLocation();
   const accountComment = useAccountComment({ commentIndex: normalizeAccountCommentIndex(params?.accountCommentIndex) });
   const resolvedCommunityAddress = useResolvedCommunityAddress();
-  const communityAddress = resolvedCommunityAddress || getCommentCommunityAddress(accountComment);
+  const communityAddress = resolvedCommunityAddress || getCommentCommunityAddress(accountComment) || getCommentCommunityAddress(getPendingPostRoutePost(location.state));
 
   return (
     <>

--- a/src/components/boards-bar/boards-bar.tsx
+++ b/src/components/boards-bar/boards-bar.tsx
@@ -288,7 +288,11 @@ const BoardsBarDesktop = memo(() => {
         ]
       </span>
       <span className={styles.navTopRight}>
-        [<Link to={!location.pathname.endsWith('settings') ? location.pathname.replace(/\/$/, '') + '/settings' : location.pathname}>{t('settings')}</Link>] [
+        [
+        <Link to={!location.pathname.endsWith('settings') ? location.pathname.replace(/\/$/, '') + '/settings' : location.pathname} state={location.state}>
+          {t('settings')}
+        </Link>
+        ] [
         <button
           type='button'
           tabIndex={0}
@@ -399,7 +403,9 @@ const BoardsBarMobile = memo(({ communityAddress }: { communityAddress?: string 
         {boardSelect}
       </div>
       <div className={styles.pageJump}>
-        <Link to={location.pathname.replace(/\/$/, '') + '/settings'}>{t('settings')}</Link>
+        <Link to={location.pathname.replace(/\/$/, '') + '/settings'} state={location.state}>
+          {t('settings')}
+        </Link>
         <button
           type='button'
           tabIndex={0}

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -1779,6 +1779,34 @@ describe('PostForm', () => {
     usePendingPostNavigationStore.getState().clearPendingPostNavigation();
   });
 
+  it('does not navigate again when the completed index matches the synchronous handoff', async () => {
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+    const pendingPost = {
+      communityAddress: 'music-posting.eth',
+      content: 'Thread body',
+      index: 7,
+    };
+    testState.publishPostMock.mockImplementation(() => {
+      testState.onPendingPost?.(7, pendingPost);
+      testState.postIndex = 7;
+    });
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    const table = container.querySelector('table') as HTMLTableElement;
+    await dispatchInput(table.querySelector('textarea') as HTMLTextAreaElement, 'Thread body');
+    await clickByText(table, 'post');
+    await flushEffects();
+
+    expect(testState.navigateMock).toHaveBeenCalledTimes(1);
+    expect(testState.navigateMock).toHaveBeenCalledWith('/pending/7', {
+      flushSync: true,
+      state: { boardPath: 'mu', pendingPost },
+    });
+    expect(testState.resetPublishPostOptionsMock).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the optimistic handoff when pending navigation throws', async () => {
     testState.navigateMock.mockImplementation(() => {
       throw new Error('navigation failed');

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PostForm, { LinkTypePreviewer } from '../post-form';
 import { OEKAKI_WEB_WARNING_TEXT } from '../../../lib/oekaki/oekaki-copy';
 import { POST_OPTIONS_VALIDATION_DELAY_MS } from '../../../lib/utils/post-options-utils';
+import usePendingPostNavigationStore from '../../../stores/use-pending-post-navigation-store';
 import usePostFormDraftsStore from '../../../stores/use-post-form-drafts-store';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -43,6 +44,9 @@ const testState = vi.hoisted(() => ({
   isResolvingExternalQuotes: false,
   mediaHostingRuntime: 'web' as 'web' | 'android' | 'electron',
   navigateMock: vi.fn(),
+  onAbandonPost: undefined as undefined | (() => void),
+  onPublishError: undefined as undefined | ((error: Error) => void),
+  onPendingPost: undefined as undefined | ((accountCommentIndex: number, pendingPost: Record<string, unknown>) => void),
   offlineTitle: 'offline board',
   postIndex: undefined as number | undefined,
   publishedPostOptions: undefined as Record<string, unknown> | undefined,
@@ -207,8 +211,21 @@ vi.mock('../../../hooks/use-publish-post', async () => {
   const React = await vi.importActual<typeof import('react')>('react');
 
   return {
-    default: ({ communityAddress }: { communityAddress?: string }) => {
+    default: ({
+      communityAddress,
+      onAbandonPost,
+      onPublishError,
+      onPendingPost,
+    }: {
+      communityAddress?: string;
+      onAbandonPost?: () => void;
+      onPublishError?: (error: Error) => void;
+      onPendingPost?: (accountCommentIndex: number, pendingPost: Record<string, unknown>) => void;
+    }) => {
       const [, forceUpdate] = React.useReducer((value: number) => value + 1, 0);
+      testState.onAbandonPost = onAbandonPost;
+      testState.onPublishError = onPublishError;
+      testState.onPendingPost = onPendingPost;
       const getPublishPostOptions = React.useCallback(
         () => ({
           ...(communityAddress ? { communityAddress } : {}),
@@ -546,6 +563,7 @@ describe('PostForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     usePostFormDraftsStore.setState({ forms: {} });
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
     testState.account = {
       author: { address: 'alice.eth', displayName: 'Alice' },
       subscriptions: ['music-posting.eth'],
@@ -580,6 +598,9 @@ describe('PostForm', () => {
     testState.isResolvingExternalQuotes = false;
     testState.mediaHostingRuntime = 'web';
     testState.offlineTitle = 'offline board';
+    testState.onAbandonPost = undefined;
+    testState.onPublishError = undefined;
+    testState.onPendingPost = undefined;
     testState.postIndex = undefined;
     testState.publishedPostOptions = undefined;
     testState.publishPostOptions = {};
@@ -620,6 +641,7 @@ describe('PostForm', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
   });
 
   it('shows the closed-thread notice when the current post can no longer receive replies', async () => {
@@ -1725,10 +1747,68 @@ describe('PostForm', () => {
     expect(testState.navigateMock).toHaveBeenCalledWith('/pending/7', { state: { boardPath: 'mu' } });
   });
 
+  it('navigates as soon as the pending comment is created without waiting for index state', async () => {
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+    const pendingPost = {
+      communityAddress: 'music-posting.eth',
+      content: 'Thread body',
+      index: 7,
+    };
+    testState.publishPostMock.mockImplementation(() => {
+      testState.onPendingPost?.(7, pendingPost);
+    });
+    const pendingNavigationStates: boolean[] = [];
+    const unsubscribe = usePendingPostNavigationStore.subscribe((state) => pendingNavigationStates.push(state.isNavigatingToPendingPost));
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    const table = container.querySelector('table') as HTMLTableElement;
+    const textarea = table.querySelector('textarea') as HTMLTextAreaElement;
+    await dispatchInput(textarea, 'Thread body');
+    await clickByText(table, 'post');
+
+    expect(testState.navigateMock).toHaveBeenCalledWith('/pending/7', {
+      flushSync: true,
+      state: { boardPath: 'mu', pendingPost },
+    });
+    expect(pendingNavigationStates).toEqual([true]);
+    expect(usePendingPostNavigationStore.getState().pendingPostNavigationIndex).toBe(7);
+    expect(container.querySelector('table')).toBeNull();
+    unsubscribe();
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
+  });
+
+  it('clears the optimistic handoff when pending navigation throws', async () => {
+    testState.navigateMock.mockImplementation(() => {
+      throw new Error('navigation failed');
+    });
+    const pendingPost = {
+      communityAddress: 'music-posting.eth',
+      index: 7,
+    };
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    expect(() => testState.onPendingPost?.(7, pendingPost)).toThrow('navigation failed');
+    expect(usePendingPostNavigationStore.getState()).toMatchObject({
+      isNavigatingToPendingPost: false,
+      pendingPostNavigationIndex: null,
+    });
+  });
+
   it('redirects new posts to the board index when nonoko is used', async () => {
     testState.resolvedCommunityAddress = 'music-posting.eth';
     testState.publishPostMock.mockImplementation(() => {
-      testState.postIndex = 7;
+      testState.onPendingPost?.(8, {
+        communityAddress: 'music-posting.eth',
+        index: 8,
+      });
+      testState.onPendingPost?.(7, {
+        communityAddress: 'music-posting.eth',
+        index: 7,
+      });
     });
 
     await renderPostForm('/mu');
@@ -1741,12 +1821,61 @@ describe('PostForm', () => {
     await dispatchInput(optionsInput as HTMLInputElement, 'nonoko');
     await dispatchInput(subjectInput as HTMLInputElement, 'Thread title');
     await clickByText(table as HTMLTableElement, 'post');
-    await flushEffects();
 
     expect(testState.publishPostMock).toHaveBeenCalledTimes(1);
-    expect(testState.resetPublishPostOptionsMock).toHaveBeenCalled();
-    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { state: { nonokoPendingAccountCommentIndex: 7 } });
-    expect(testState.navigateMock).not.toHaveBeenCalledWith('/pending/7');
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { flushSync: true, state: { nonokoPendingAccountCommentIndex: 8 } });
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { flushSync: true, state: { nonokoPendingAccountCommentIndex: 7 } });
+    expect(testState.navigateMock.mock.calls.some(([path]) => typeof path === 'string' && path.startsWith('/pending/'))).toBe(false);
+  });
+
+  it('clears the optimistic handoff when publishing fails after navigation', async () => {
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+    testState.publishPostMock.mockImplementation(() => {
+      testState.onPendingPost?.(7, {
+        communityAddress: 'music-posting.eth',
+        index: 7,
+      });
+      testState.onPublishError?.(new Error('persistence failed'));
+    });
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    const table = container.querySelector('table') as HTMLTableElement;
+    await dispatchInput(table.querySelector('textarea') as HTMLTextAreaElement, 'Thread body');
+    await clickByText(table, 'post');
+
+    expect(testState.navigateMock).toHaveBeenLastCalledWith('/pending/7', {
+      flushSync: true,
+      state: {
+        boardPath: 'mu',
+        pendingPost: {
+          communityAddress: 'music-posting.eth',
+          index: 7,
+        },
+      },
+    });
+    expect(usePendingPostNavigationStore.getState()).toMatchObject({
+      isNavigatingToPendingPost: true,
+      pendingPostNavigationIndex: null,
+    });
+  });
+
+  it('does not let a late publish error clear a newer optimistic handoff', async () => {
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+    testState.onPendingPost?.(7, {
+      communityAddress: 'music-posting.eth',
+      index: 7,
+    });
+    const oldPublishError = testState.onPublishError;
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(8);
+
+    oldPublishError?.(new Error('late failure'));
+
+    expect(usePendingPostNavigationStore.getState().pendingPostNavigationIndex).toBe(8);
   });
 
   it('resets the reply form after a completed reply publish', async () => {

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -1745,6 +1745,7 @@ describe('PostForm', () => {
     expect(testState.resetPublishPostOptionsMock).toHaveBeenCalled();
     expect(usePostFormDraftsStore.getState().forms['/mu']).toBeUndefined();
     expect(testState.navigateMock).toHaveBeenCalledWith('/pending/7', { state: { boardPath: 'mu' } });
+    expect(usePendingPostNavigationStore.getState().pendingPostNavigationIndex).toBe(7);
   });
 
   it('navigates as soon as the pending comment is created without waiting for index state', async () => {

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -1906,6 +1906,25 @@ describe('PostForm', () => {
     expect(usePendingPostNavigationStore.getState().pendingPostNavigationIndex).toBe(8);
   });
 
+  it('does not let an older publish abandonment clear a newer optimistic handoff', async () => {
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+    testState.onPendingPost?.(7, {
+      communityAddress: 'music-posting.eth',
+      index: 7,
+    });
+    const oldAbandonPost = testState.onAbandonPost;
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(8);
+    testState.navigateMock.mockClear();
+
+    oldAbandonPost?.();
+
+    expect(usePendingPostNavigationStore.getState().pendingPostNavigationIndex).toBe(8);
+    expect(testState.navigateMock).not.toHaveBeenCalled();
+  });
+
   it('resets the reply form after a completed reply publish', async () => {
     testState.comments = {
       'thread-cid': {

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -871,6 +871,8 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
       if (nonokoRedirectPath) {
         navigate(nonokoRedirectPath, { state: getNonokoPendingRouteState(postIndex) });
       } else {
+        pendingPostNavigationIndexRef.current = postIndex;
+        usePendingPostNavigationStore.getState().beginPendingPostNavigation(postIndex);
         navigate(`/pending/${postIndex}`, pendingPostBoardPath ? { state: { boardPath: pendingPostBoardPath } } : undefined);
       }
     }

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -35,6 +36,8 @@ import { isValidURL } from '../../lib/utils/url-utils';
 import { getModerationPostingRoleLabel } from '../../lib/utils/author-display-utils';
 import { hasModQueueAccessRole } from '../../lib/utils/mod-access';
 import { getPageDraftKey } from '../../lib/utils/location-draft-utils';
+import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
+import { getPendingPostRoutePost } from '../../lib/utils/pending-post-route-state';
 import { getBoardPath, isDirectoryRoute } from '../../lib/utils/route-utils';
 import { isAllView, isCatalogView, isModQueueView, isModView, isPostPageView, isSubscriptionsView } from '../../lib/utils/view-utils';
 import { getCommentFlagOptionsForDirectory, getCommentFlagPublishOptionsForDirectory, type CommentFlagSelectOption } from '../../lib/comment-flag-selection';
@@ -58,6 +61,7 @@ import { getShowUploadControls, isWebRuntime } from '../../lib/media-hosting/sho
 import { OEKAKI_WEB_WARNING_TEXT } from '../../lib/oekaki/oekaki-copy';
 import { isCommentArchived } from '../../lib/utils/comment-moderation-utils';
 import useMediaHostingStore from '../../stores/use-media-hosting-store';
+import usePendingPostNavigationStore from '../../stores/use-pending-post-navigation-store';
 import usePostFormDraftsStore, { EMPTY_POST_FORM_STATE, type PostFormDraft } from '../../stores/use-post-form-drafts-store';
 import BoardOfflineAlert from '../board-offline-alert/board-offline-alert';
 import BbcodeEditorToolbar, { BbcodePreview } from '../bbcode-editor-toolbar/bbcode-editor-toolbar';
@@ -601,9 +605,57 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   const { displayName } = author || {};
   const accountComment = useAccountComment({ commentIndex: normalizeAccountCommentIndex(params?.accountCommentIndex) });
   const resolvedAddress = useResolvedCommunityAddress();
-  const communityAddress = resolvedAddress || accountComment?.communityAddress;
+  const communityAddress = resolvedAddress || getCommentCommunityAddress(accountComment) || getCommentCommunityAddress(getPendingPostRoutePost(location.state));
+  const navigate = useNavigate();
+  const nonokoRedirectPathRef = useRef<string | null>(null);
+  const pendingPostBoardPathRef = useRef<string | undefined>(undefined);
+  const pendingPostNavigationIndexRef = useRef<number | null>(null);
+  const navigateToPendingPost = useCallback(
+    (accountCommentIndex: number, pendingPost: Comment) => {
+      const nonokoRedirectPath = nonokoRedirectPathRef.current;
+      const boardPath = pendingPostBoardPathRef.current;
+
+      if (nonokoRedirectPath) {
+        flushSync(() => navigate(nonokoRedirectPath, { flushSync: true, state: getNonokoPendingRouteState(accountCommentIndex) }));
+      } else {
+        pendingPostNavigationIndexRef.current = accountCommentIndex;
+        flushSync(() => usePendingPostNavigationStore.getState().beginPendingPostNavigation(accountCommentIndex));
+        try {
+          flushSync(() =>
+            navigate(`/pending/${accountCommentIndex}`, {
+              flushSync: true,
+              state: { ...(boardPath ? { boardPath } : {}), pendingPost },
+            }),
+          );
+        } catch (error) {
+          pendingPostNavigationIndexRef.current = null;
+          usePendingPostNavigationStore.getState().clearPendingPostNavigation(accountCommentIndex);
+          throw error;
+        }
+      }
+      closeForm();
+    },
+    [closeForm, navigate],
+  );
+  const navigateAfterAbandon = useCallback(() => {
+    const boardPath = pendingPostBoardPathRef.current;
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
+    if (boardPath) {
+      flushSync(() => navigate(`/${boardPath}`, { flushSync: true, replace: true }));
+    }
+  }, [navigate]);
+  const clearPendingPostHandoffAfterPublishError = useCallback(() => {
+    const pendingPostNavigationIndex = pendingPostNavigationIndexRef.current;
+    pendingPostNavigationIndexRef.current = null;
+    if (pendingPostNavigationIndex !== null) {
+      usePendingPostNavigationStore.getState().clearPendingPostHandoff(pendingPostNavigationIndex);
+    }
+  }, []);
   const { setPublishPostOptions, postIndex, publishPost, publishPostError, publishPostOptions, resetPublishPostOptions } = usePublishPost({
     communityAddress,
+    onAbandonPost: navigateAfterAbandon,
+    onPublishError: clearPendingPostHandoffAfterPublishError,
+    onPendingPost: navigateToPendingPost,
   });
   const effectiveBoardAddress = communityAddress || draft.communityAddress || publishPostOptions.communityAddress;
 
@@ -615,7 +667,6 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   const flashTagRef = useRef<HTMLSelectElement>(null);
   const fortuneEntryRef = useRef<FortuneEntry | null>(null);
   const diceRollRef = useRef<DiceRoll | null>(null);
-  const nonokoRedirectPathRef = useRef<string | null>(null);
 
   const isInPostView = isPostPageView(location.pathname, params);
   const isInAllView = isAllView(location.pathname);
@@ -733,6 +784,7 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
       setLengthError(null);
       setFormError(null);
       nonokoRedirectPathRef.current = null;
+      pendingPostNavigationIndexRef.current = null;
 
       if (currentOptionsError) {
         setFormError(currentOptionsError);
@@ -780,6 +832,7 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
       };
 
       nonokoRedirectPathRef.current = hasNonokoOption(currentOptions) ? getBoardIndexPath() : null;
+      pendingPostBoardPathRef.current = pendingPostBoardPath;
       await publishPost({
         content: publishContent,
         ...getPublishLinkOptions(currentUrl, appliedYouTubeConversion || (hasRestoredDraftRef.current && Boolean(currentUrl))),
@@ -791,7 +844,6 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
     });
 
   // redirect to pending page when pending comment is created
-  const navigate = useNavigate();
   useEffect(() => {
     if (typeof postIndex === 'number') {
       const nonokoRedirectPath = nonokoRedirectPathRef.current;

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -609,11 +609,13 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   const navigate = useNavigate();
   const nonokoRedirectPathRef = useRef<string | null>(null);
   const pendingPostBoardPathRef = useRef<string | undefined>(undefined);
+  const handledPendingPostIndexRef = useRef<number | null>(null);
   const pendingPostNavigationIndexRef = useRef<number | null>(null);
   const navigateToPendingPost = useCallback(
     (accountCommentIndex: number, pendingPost: Comment) => {
       const nonokoRedirectPath = nonokoRedirectPathRef.current;
       const boardPath = pendingPostBoardPathRef.current;
+      handledPendingPostIndexRef.current = accountCommentIndex;
       pendingPostNavigationIndexRef.current = accountCommentIndex;
 
       if (nonokoRedirectPath) {
@@ -628,6 +630,7 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
             }),
           );
         } catch (error) {
+          handledPendingPostIndexRef.current = null;
           pendingPostNavigationIndexRef.current = null;
           usePendingPostNavigationStore.getState().clearPendingPostNavigation(accountCommentIndex);
           throw error;
@@ -639,7 +642,15 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   );
   const navigateAfterAbandon = useCallback(() => {
     const boardPath = pendingPostBoardPathRef.current;
-    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
+    const pendingPostNavigationIndex = pendingPostNavigationIndexRef.current;
+    const activePendingPostNavigationIndex = usePendingPostNavigationStore.getState().pendingPostNavigationIndex;
+    if (activePendingPostNavigationIndex !== null && activePendingPostNavigationIndex !== pendingPostNavigationIndex) {
+      return;
+    }
+    pendingPostNavigationIndexRef.current = null;
+    if (pendingPostNavigationIndex !== null) {
+      usePendingPostNavigationStore.getState().clearPendingPostNavigation(pendingPostNavigationIndex);
+    }
     if (boardPath) {
       flushSync(() => navigate(`/${boardPath}`, { flushSync: true, replace: true }));
     }
@@ -784,6 +795,7 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
       setLengthError(null);
       setFormError(null);
       nonokoRedirectPathRef.current = null;
+      handledPendingPostIndexRef.current = null;
       pendingPostNavigationIndexRef.current = null;
 
       if (currentOptionsError) {
@@ -846,8 +858,8 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   // redirect to pending page when pending comment is created
   useEffect(() => {
     if (typeof postIndex === 'number') {
-      const alreadyNavigatedToPostIndex = pendingPostNavigationIndexRef.current === postIndex;
-      pendingPostNavigationIndexRef.current = null;
+      const alreadyNavigatedToPostIndex = handledPendingPostIndexRef.current === postIndex;
+      handledPendingPostIndexRef.current = null;
       const nonokoRedirectPath = nonokoRedirectPathRef.current;
       nonokoRedirectPathRef.current = null;
       resetPublishPostOptions();

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -614,11 +614,11 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
     (accountCommentIndex: number, pendingPost: Comment) => {
       const nonokoRedirectPath = nonokoRedirectPathRef.current;
       const boardPath = pendingPostBoardPathRef.current;
+      pendingPostNavigationIndexRef.current = accountCommentIndex;
 
       if (nonokoRedirectPath) {
         flushSync(() => navigate(nonokoRedirectPath, { flushSync: true, state: getNonokoPendingRouteState(accountCommentIndex) }));
       } else {
-        pendingPostNavigationIndexRef.current = accountCommentIndex;
         flushSync(() => usePendingPostNavigationStore.getState().beginPendingPostNavigation(accountCommentIndex));
         try {
           flushSync(() =>
@@ -846,11 +846,16 @@ const PostFormTable = ({ closeForm, draftKey, postCid }: { closeForm: () => void
   // redirect to pending page when pending comment is created
   useEffect(() => {
     if (typeof postIndex === 'number') {
+      const alreadyNavigatedToPostIndex = pendingPostNavigationIndexRef.current === postIndex;
+      pendingPostNavigationIndexRef.current = null;
       const nonokoRedirectPath = nonokoRedirectPathRef.current;
       nonokoRedirectPathRef.current = null;
       resetPublishPostOptions();
       resetFields();
       closeForm();
+      if (alreadyNavigatedToPostIndex) {
+        return;
+      }
       if (nonokoRedirectPath) {
         navigate(nonokoRedirectPath, { state: getNonokoPendingRouteState(postIndex) });
       } else {

--- a/src/components/settings-modal/__tests__/settings-modal.test.tsx
+++ b/src/components/settings-modal/__tests__/settings-modal.test.tsx
@@ -70,13 +70,17 @@ vi.mock('../p2p-stats-settings/p2p-stats-settings', () => ({
 
 const LocationProbe = () => {
   const location = useLocation();
-  return <div data-testid='location'>{location.pathname + location.search + location.hash}</div>;
+  return (
+    <div data-testid='location' data-state={JSON.stringify(location.state)}>
+      {location.pathname + location.search + location.hash}
+    </div>
+  );
 };
 
 let root: Root;
 let container: HTMLDivElement;
 
-const render = async (initialEntry = '/all/settings') => {
+const render = async (initialEntry: string | { pathname: string; state?: unknown } = '/all/settings') => {
   await act(async () => {
     root.render(
       createElement(MemoryRouter, { initialEntries: [initialEntry] }, createElement(React.Fragment, {}, createElement(SettingsModal), createElement(LocationProbe))),
@@ -85,6 +89,7 @@ const render = async (initialEntry = '/all/settings') => {
 };
 
 const getLocationText = () => container.querySelector('[data-testid="location"]')?.textContent ?? '';
+const getLocationState = () => container.querySelector('[data-testid="location"]')?.getAttribute('data-state');
 
 const getSectionToggleByText = (text: string) => {
   const control = Array.from(container.querySelectorAll<HTMLElement>('label, button')).find((candidate) => (candidate.textContent ?? '').includes(text));
@@ -157,6 +162,28 @@ describe('SettingsModal', () => {
 
     expect(getLocationText()).toBe('/all/settings');
     expect(container.querySelector('[data-testid="account-settings"]')).toBeNull();
+  });
+
+  it('preserves pending route state while using and closing settings', async () => {
+    const routeState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 7 },
+    };
+    await render({ pathname: '/pending/7/settings', state: routeState });
+
+    await act(async () => {
+      getSectionToggleByText('interface').click();
+    });
+
+    expect(getLocationText()).toBe('/pending/7/settings?section=interface-settings');
+    expect(getLocationState()).toBe(JSON.stringify(routeState));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="close"]')?.click();
+    });
+
+    expect(getLocationText()).toBe('/pending/7');
+    expect(getLocationState()).toBe(JSON.stringify(routeState));
   });
 
   it('expands and collapses all settings sections', async () => {

--- a/src/components/settings-modal/settings-modal.tsx
+++ b/src/components/settings-modal/settings-modal.tsx
@@ -37,7 +37,7 @@ const SettingsModal = () => {
   const { t } = useTranslation();
   const account = useAccount();
   const pkcRpc = usePkcRpcSettings();
-  const { hash: locationHash, pathname, search } = useLocation();
+  const { hash: locationHash, pathname, search, state } = useLocation();
   const navigate = useNavigate();
   const hiddenReviewUpgradeKeys = useSettingsUpgradeReviewStore((state) => state.hiddenReviewUpgradeKeys);
   const reviewUpgradeKeys = useSettingsUpgradeReviewStore((state) => state.reviewUpgradeKeys);
@@ -56,8 +56,8 @@ const SettingsModal = () => {
 
   const closeModal = useCallback(() => {
     const newPath = pathname.replace(/\/settings$/, '');
-    navigate(newPath);
-  }, [pathname, navigate]);
+    navigate(newPath, { state });
+  }, [pathname, navigate, state]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -104,22 +104,22 @@ const SettingsModal = () => {
     setExpandedSections(next);
 
     if (isOpening) {
-      navigate(getSettingsSectionPath(pathname, categoryId, search), { replace: true });
+      navigate(getSettingsSectionPath(pathname, categoryId, search), { replace: true, state });
     } else if (next.size === 1) {
       const remaining = next.values().next().value;
-      navigate(getSettingsSectionPath(pathname, remaining ?? null, search), { replace: true });
+      navigate(getSettingsSectionPath(pathname, remaining ?? null, search), { replace: true, state });
     } else {
-      navigate(getSettingsSectionPath(pathname, null, search), { replace: true });
+      navigate(getSettingsSectionPath(pathname, null, search), { replace: true, state });
     }
   };
 
   const handleExpandAll = () => {
     if (allExpanded) {
       setExpandedSections(new Set());
-      navigate(getSettingsSectionPath(pathname, null, search), { replace: true });
+      navigate(getSettingsSectionPath(pathname, null, search), { replace: true, state });
     } else {
       setExpandedSections(new Set(sectionIds));
-      navigate(getSettingsSectionPath(pathname, null, search), { replace: true });
+      navigate(getSettingsSectionPath(pathname, null, search), { replace: true, state });
     }
   };
 

--- a/src/hooks/__tests__/use-publish-post.test.tsx
+++ b/src/hooks/__tests__/use-publish-post.test.tsx
@@ -10,11 +10,14 @@ import usePublishPostStore from '../../stores/use-publish-post-store';
 const act = (React as { act?: (cb: () => void | Promise<void>) => void | Promise<void> }).act as (cb: () => void | Promise<void>) => void | Promise<void>;
 
 const testState = vi.hoisted(() => ({
+  abandonNavigationMock: vi.fn(),
   abandonPublishMock: vi.fn(async () => undefined),
   index: 12,
   lastPublishOptions: undefined as Record<string, any> | undefined,
   publishAuthorBlockedReason: undefined as 'resolving' | 'unresolved' | 'mismatch' | undefined,
   publishCommentMock: vi.fn(),
+  publishErrorNavigationMock: vi.fn(),
+  pendingPostNavigationMock: vi.fn(),
 }));
 
 vi.mock('@bitsocial/bitsocial-react-hooks', () => ({
@@ -41,7 +44,12 @@ let latestValue: ReturnType<typeof usePublishPost>;
 let root: Root;
 
 const HookHarness = () => {
-  latestValue = usePublishPost({ communityAddress: 'music.eth' });
+  latestValue = usePublishPost({
+    communityAddress: 'music.eth',
+    onAbandonPost: testState.abandonNavigationMock,
+    onPublishError: testState.publishErrorNavigationMock,
+    onPendingPost: testState.pendingPostNavigationMock,
+  });
   return null;
 };
 
@@ -117,13 +125,40 @@ describe('usePublishPost', () => {
       await useChallengesStore.getState().abandonCurrentChallenge();
     });
 
+    expect(testState.abandonNavigationMock).toHaveBeenCalledTimes(1);
     expect(testState.abandonPublishMock).toHaveBeenCalledTimes(1);
+    expect(testState.abandonNavigationMock.mock.invocationCallOrder[0]).toBeLessThan(testState.abandonPublishMock.mock.invocationCallOrder[0]);
 
     await act(async () => {
       latestValue.resetPublishPostOptions();
     });
 
     expect(latestValue.publishPostOptions).toEqual({});
+  });
+
+  it('forwards pending comments before the index state update is rendered', async () => {
+    const pendingPost = { communityAddress: 'music.eth', content: 'Thread body', index: 12 };
+
+    await act(async () => {
+      await testState.lastPublishOptions?.onPendingComment?.(12, pendingPost);
+    });
+
+    expect(testState.pendingPostNavigationMock).toHaveBeenCalledWith(12, pendingPost);
+  });
+
+  it('handles optimistic navigation before forwarding publish errors', async () => {
+    const existingOnError = vi.fn();
+    const error = new Error('publish failed');
+    usePublishPostStore.setState({ publishCommentOptions: { onError: existingOnError } });
+    renderHook();
+
+    await act(async () => {
+      testState.lastPublishOptions?.onError?.(error);
+    });
+
+    expect(testState.publishErrorNavigationMock).toHaveBeenCalledWith(error);
+    expect(existingOnError).toHaveBeenCalledWith(error);
+    expect(testState.publishErrorNavigationMock.mock.invocationCallOrder[0]).toBeLessThan(existingOnError.mock.invocationCallOrder[0]);
   });
 
   it('blocks publish when the active account address is a domain that is not verified yet', async () => {

--- a/src/hooks/__tests__/use-theme.test.tsx
+++ b/src/hooks/__tests__/use-theme.test.tsx
@@ -13,6 +13,7 @@ const testState = vi.hoisted(() => ({
   directories: [] as Array<{ address: string; nsfw?: boolean }>,
   isSpecialThemeEnabled: false as boolean | null,
   locationPathname: '/trash',
+  locationState: null as { pendingPost?: { communityAddress?: string } } | null,
   resolvedAddress: 'off-topic.bso' as string | undefined,
   setIsEnabledMock: vi.fn(),
   setThemeMock: vi.fn().mockResolvedValue(undefined),
@@ -27,7 +28,7 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
-    useLocation: () => ({ pathname: testState.locationPathname }),
+    useLocation: () => ({ pathname: testState.locationPathname, state: testState.locationState }),
     useParams: () => ({ boardIdentifier: testState.boardIdentifier }),
   };
 });
@@ -92,6 +93,7 @@ describe('useTheme', () => {
     testState.directories = [];
     testState.isSpecialThemeEnabled = false;
     testState.locationPathname = `/${TRASH_BOARD_CODE}`;
+    testState.locationState = null;
     testState.resolvedAddress = TRASH_BOARD_ADDRESS;
     testState.themes = {
       nsfw: 'tomorrow',
@@ -133,5 +135,19 @@ describe('useTheme', () => {
     await renderHook();
 
     expect(testState.updateFaviconMock).toHaveBeenLastCalledWith('default');
+  });
+
+  it('keeps the board theme while an optimistic pending post is being persisted', async () => {
+    testState.boardIdentifier = undefined;
+    testState.directories = [{ address: 'music-posting.eth', nsfw: true }];
+    testState.locationPathname = '/pending/0';
+    testState.locationState = { pendingPost: { communityAddress: 'music-posting.eth' } };
+    testState.resolvedAddress = undefined;
+
+    await renderHook();
+
+    expect(latestValue?.[0]).toBe('tomorrow');
+    expect(document.body.classList.contains('tomorrow')).toBe(true);
+    expect(document.body.classList.contains('yotsuba')).toBe(false);
   });
 });

--- a/src/hooks/use-publish-post.ts
+++ b/src/hooks/use-publish-post.ts
@@ -8,9 +8,12 @@ import usePendingPublishRequest from './use-pending-publish-request';
 
 type UsePublishPostOptions = {
   communityAddress?: string;
+  onAbandonPost?: () => void;
+  onPublishError?: (error: Error) => void;
+  onPendingPost?: (accountCommentIndex: number, pendingPost: Comment) => void;
 };
 
-const usePublishPost = ({ communityAddress }: UsePublishPostOptions) => {
+const usePublishPost = ({ communityAddress, onAbandonPost, onPublishError, onPendingPost }: UsePublishPostOptions) => {
   const { author, title, content, link, flairs, spoiler, publishCommentOptions } = usePublishPostStore(
     useShallow((state) => ({
       author: state.author,
@@ -33,8 +36,9 @@ const usePublishPost = ({ communityAddress }: UsePublishPostOptions) => {
   const { blockedReason } = usePublishAuthorDomainGuard();
   const { finishPendingPublishRequest, startPendingPublishRequest } = usePendingPublishRequest();
   const abandonCurrentPublish = useCallback(async () => {
+    onAbandonPost?.();
     await abandonPublishRef.current?.();
-  }, []);
+  }, [onAbandonPost]);
 
   const createBaseOptions = useCallback(() => {
     const baseOptions: Comment = {
@@ -83,11 +87,16 @@ const usePublishPost = ({ communityAddress }: UsePublishPostOptions) => {
   const publishOptionsWithAbandon = useMemo(
     () => ({
       ...publishCommentOptions,
+      onPendingComment: onPendingPost,
+      onError: (error: Error) => {
+        onPublishError?.(error);
+        publishCommentOptions.onError?.(error);
+      },
       onChallenge: async (...args: any[]) => {
         addChallenge(args, abandonCurrentPublish);
       },
     }),
-    [abandonCurrentPublish, addChallenge, publishCommentOptions],
+    [abandonCurrentPublish, addChallenge, onPendingPost, onPublishError, publishCommentOptions],
   );
 
   const { index, publishComment, abandonPublish } = usePublishComment(publishOptionsWithAbandon);

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -11,6 +11,7 @@ import { getSpecialBoardByAddress } from '../lib/special-boards';
 import { isSfwBoard, updateFavicon } from '../lib/update-favicon';
 import { getCommentCommunityAddress } from '../lib/utils/comment-utils';
 import { normalizeAccountCommentIndex } from '../lib/utils/account-comment-index-utils';
+import { getPendingPostRoutePost } from '../lib/utils/pending-post-route-state';
 
 const themeClasses = ['yotsuba', 'yotsuba-b', 'futaba', 'burichan', 'tomorrow', 'photon', 'spooky'];
 
@@ -30,6 +31,7 @@ const useTheme = ({ applyDocumentEffects = false }: UseThemeOptions = {}): [stri
   const params = useParams<{ accountCommentIndex?: string; boardIdentifier?: string; commentCid?: string }>();
   const pendingPost = useAccountComment({ commentIndex: normalizeAccountCommentIndex(params?.accountCommentIndex) });
   const pendingPostCommunityAddress = getCommentCommunityAddress(pendingPost);
+  const routePendingPostCommunityAddress = getCommentCommunityAddress(getPendingPostRoutePost(location.state));
 
   const { isEnabled, setIsEnabled } = useSpecialThemeStore();
 
@@ -43,7 +45,7 @@ const useTheme = ({ applyDocumentEffects = false }: UseThemeOptions = {}): [stri
   const isInNotFoundView = isNotFoundView(location.pathname, params);
   const routeIdentifier = params.boardIdentifier;
   const resolvedAddress = useResolvedCommunityAddress();
-  const communityAddress = resolvedAddress || pendingPostCommunityAddress || routeIdentifier;
+  const communityAddress = resolvedAddress || pendingPostCommunityAddress || routePendingPostCommunityAddress || routeIdentifier;
   const activeSpecialTheme = getActiveSpecialTheme();
 
   useEffect(() => {

--- a/src/lib/utils/pending-post-route-state.ts
+++ b/src/lib/utils/pending-post-route-state.ts
@@ -1,0 +1,19 @@
+import type { Comment } from '@bitsocial/bitsocial-react-hooks';
+
+export const getPendingPostRouteBoardPath = (state: unknown): string | undefined => {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+
+  const boardPath = (state as { boardPath?: unknown }).boardPath;
+  return typeof boardPath === 'string' && boardPath ? boardPath : undefined;
+};
+
+export const getPendingPostRoutePost = (state: unknown): Comment | undefined => {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+
+  const pendingPost = (state as { pendingPost?: unknown }).pendingPost;
+  return pendingPost && typeof pendingPost === 'object' ? (pendingPost as Comment) : undefined;
+};

--- a/src/stores/use-pending-post-navigation-store.ts
+++ b/src/stores/use-pending-post-navigation-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface PendingPostNavigationState {
+  pendingPostNavigationIndex: number | null;
+  isNavigatingToPendingPost: boolean;
+  beginPendingPostNavigation: (accountCommentIndex: number) => void;
+  completePendingPostNavigation: () => void;
+  clearPendingPostHandoff: (accountCommentIndex?: number) => void;
+  clearPendingPostNavigation: (accountCommentIndex?: number) => void;
+}
+
+const usePendingPostNavigationStore = create<PendingPostNavigationState>((set) => ({
+  pendingPostNavigationIndex: null,
+  isNavigatingToPendingPost: false,
+  beginPendingPostNavigation: (pendingPostNavigationIndex) => set({ isNavigatingToPendingPost: true, pendingPostNavigationIndex }),
+  completePendingPostNavigation: () => set({ isNavigatingToPendingPost: false }),
+  clearPendingPostHandoff: (accountCommentIndex) =>
+    set((state) => (accountCommentIndex === undefined || state.pendingPostNavigationIndex === accountCommentIndex ? { pendingPostNavigationIndex: null } : state)),
+  clearPendingPostNavigation: (accountCommentIndex) =>
+    set((state) =>
+      accountCommentIndex === undefined || state.pendingPostNavigationIndex === accountCommentIndex
+        ? { isNavigatingToPendingPost: false, pendingPostNavigationIndex: null }
+        : state,
+    ),
+}));
+
+export default usePendingPostNavigationStore;

--- a/src/views/pending-post/__tests__/pending-post.test.tsx
+++ b/src/views/pending-post/__tests__/pending-post.test.tsx
@@ -336,6 +336,36 @@ describe('PendingPost', () => {
     cancelAnimationFrameSpy.mockRestore();
   });
 
+  it('does not complete a newer pending handoff when the previous route cleans up', async () => {
+    let frameId = 0;
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++frameId);
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+
+    try {
+      testState.accountCommentIndex = '0';
+      testState.accountComments = [{ index: 0 }];
+      testState.locationState = { boardPath: 'mu', pendingPost: { communityAddress: 'music-posting.eth', index: 0 } };
+      usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+
+      await renderPendingPost();
+
+      testState.accountCommentIndex = '1';
+      testState.accountComments = [{ index: 0 }, { index: 1 }];
+      testState.locationState = { boardPath: 'mu', pendingPost: { communityAddress: 'music-posting.eth', index: 1 } };
+      act(() => usePendingPostNavigationStore.getState().beginPendingPostNavigation(1));
+
+      await renderPendingPost();
+
+      expect(usePendingPostNavigationStore.getState()).toMatchObject({
+        isNavigatingToPendingPost: true,
+        pendingPostNavigationIndex: 1,
+      });
+    } finally {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    }
+  });
+
   it('redirects abandoned pending posts back to their board after the challenge closes', async () => {
     testState.accountCommentIndex = '0';
     testState.accountComments = [];

--- a/src/views/pending-post/__tests__/pending-post.test.tsx
+++ b/src/views/pending-post/__tests__/pending-post.test.tsx
@@ -71,9 +71,16 @@ vi.mock('../../../stores/use-failed-post-retry-store', () => ({
     selector({ retryingAccountCommentIndex: testState.retryingAccountCommentIndex }),
 }));
 
-vi.mock('../../post/post', () => ({
-  Post: ({ post }: { post?: TestComment }) => createElement('div', { 'data-testid': 'post-view' }, post?.cid ?? 'no-post'),
-}));
+vi.mock('../../post/post', async () => {
+  const { createElement, memo } = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    Post: memo(
+      ({ post }: { post?: TestComment }) => createElement('div', { 'data-post-index': post?.index, 'data-testid': 'post-view' }, post?.cid ?? 'no-post'),
+      (previousProps, nextProps) => previousProps.post?.cid === nextProps.post?.cid,
+    ),
+  };
+});
 
 let container: HTMLDivElement;
 let root: Root;
@@ -364,6 +371,26 @@ describe('PendingPost', () => {
       requestAnimationFrameSpy.mockRestore();
       cancelAnimationFrameSpy.mockRestore();
     }
+  });
+
+  it('renders a new addressless pending post when the route index changes', async () => {
+    testState.accountCommentIndex = '0';
+    testState.accountComments = [{ index: 0 }];
+    testState.locationState = { boardPath: 'mu', pendingPost: { communityAddress: 'music-posting.eth', index: 0 } };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')?.getAttribute('data-post-index')).toBe('0');
+
+    testState.accountCommentIndex = '1';
+    testState.accountComments = [{ index: 0 }, { index: 1 }];
+    testState.locationState = { boardPath: 'mu', pendingPost: { communityAddress: 'music-posting.eth', index: 1 } };
+    act(() => usePendingPostNavigationStore.getState().beginPendingPostNavigation(1));
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')?.getAttribute('data-post-index')).toBe('1');
   });
 
   it('redirects abandoned pending posts back to their board after the challenge closes', async () => {

--- a/src/views/pending-post/__tests__/pending-post.test.tsx
+++ b/src/views/pending-post/__tests__/pending-post.test.tsx
@@ -177,10 +177,12 @@ describe('PendingPost', () => {
   it('redirects malformed pending indices to not found', async () => {
     testState.accountCommentIndex = '1abc';
     testState.accountComments = [{}, {}];
+    testState.locationState = { boardPath: 'mu' };
 
     await renderPendingPost();
 
     expect(testState.navigateMock).toHaveBeenCalledWith('/not-found', { replace: true });
+    expect(testState.navigateMock).not.toHaveBeenCalledWith('/mu', { replace: true });
   });
 
   it('redirects out-of-range pending indices to not found', async () => {

--- a/src/views/pending-post/__tests__/pending-post.test.tsx
+++ b/src/views/pending-post/__tests__/pending-post.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import usePendingPostNavigationStore from '../../../stores/use-pending-post-navigation-store';
 import PendingPost from '../pending-post';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -17,10 +18,11 @@ const testState = vi.hoisted(() => ({
   accountCommentIndex: undefined as string | undefined,
   accountCommentLookupOptions: undefined as { commentIndex?: number } | undefined,
   accountComments: [] as TestComment[],
+  accountCommentsState: 'succeeded',
   challengeCount: 0,
   directories: [] as Array<{ address: string; title?: string }>,
   getBoardPathMock: vi.fn<(address: string) => string>(),
-  locationState: null as { boardPath?: string } | null,
+  locationState: null as { boardPath?: string; pendingPost?: TestComment } | null,
   navigateMock: vi.fn(),
   post: undefined as TestComment | undefined,
   retryingAccountCommentIndex: null as number | null,
@@ -48,6 +50,7 @@ vi.mock('@bitsocial/bitsocial-react-hooks', () => ({
   },
   useAccountComments: () => ({
     accountComments: testState.accountComments,
+    state: testState.accountCommentsState,
   }),
 }));
 
@@ -98,6 +101,7 @@ describe('PendingPost', () => {
     testState.accountCommentIndex = undefined;
     testState.accountCommentLookupOptions = undefined;
     testState.accountComments = [];
+    testState.accountCommentsState = 'succeeded';
     testState.challengeCount = 0;
     testState.directories = [];
     testState.getBoardPathMock.mockReset();
@@ -105,6 +109,7 @@ describe('PendingPost', () => {
     testState.navigateMock.mockReset();
     testState.post = undefined;
     testState.retryingAccountCommentIndex = null;
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
 
     window.scrollTo = scrollToMock;
 
@@ -116,6 +121,7 @@ describe('PendingPost', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation();
     window.scrollTo = originalScrollTo;
   });
 
@@ -200,6 +206,134 @@ describe('PendingPost', () => {
     expect(testState.navigateMock).not.toHaveBeenCalledWith('/not-found', { replace: true });
   });
 
+  it('renders the route pending post before the account store update arrives', async () => {
+    testState.accountCommentIndex = '2';
+    testState.accountComments = [{ index: 0 }, { index: 1 }];
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: {
+        communityAddress: 'music-posting.eth',
+        index: 2,
+      },
+    };
+    testState.post = { index: 2 };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(2);
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).not.toBeNull();
+    expect(testState.navigateMock).not.toHaveBeenCalledWith('/not-found', { replace: true });
+  });
+
+  it('does not revive the route fallback after the stored post is abandoned', async () => {
+    testState.accountCommentIndex = '2';
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 2 },
+    };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(2);
+
+    await renderPendingPost();
+    expect(container.querySelector('[data-testid="post-view"]')).not.toBeNull();
+
+    testState.post = { communityAddress: 'music-posting.eth', index: 2 };
+    await renderPendingPost();
+
+    testState.post = undefined;
+    testState.navigateMock.mockClear();
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).toBeNull();
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { replace: true });
+  });
+
+  it('uses a fresh optimistic handoff when the pending route index changes without remounting', async () => {
+    testState.accountCommentIndex = '0';
+    testState.accountComments = [{ index: 0 }];
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 0 },
+    };
+    testState.post = { communityAddress: 'music-posting.eth', index: 0 };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+
+    await renderPendingPost();
+
+    testState.accountCommentIndex = '1';
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 1 },
+    };
+    testState.post = undefined;
+    testState.navigateMock.mockClear();
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(1);
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).not.toBeNull();
+    expect(testState.navigateMock).not.toHaveBeenCalledWith('/not-found', { replace: true });
+  });
+
+  it('does not keep stale optimistic route state after a reload clears the live handoff', async () => {
+    testState.accountCommentIndex = '2';
+    testState.accountComments = [{ index: 0 }, { index: 1 }];
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 2 },
+    };
+    testState.post = undefined;
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).toBeNull();
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { replace: true });
+  });
+
+  it('keeps a persisted failed post visible after its optimistic handoff is cleared', async () => {
+    testState.accountCommentIndex = '2';
+    testState.accountComments = [{ index: 0 }, { index: 1 }, { index: 2 }];
+    testState.locationState = {
+      boardPath: 'mu',
+      pendingPost: { communityAddress: 'music-posting.eth', index: 2 },
+    };
+    testState.post = { communityAddress: 'music-posting.eth', index: 2 };
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).not.toBeNull();
+    expect(testState.navigateMock).not.toHaveBeenCalledWith('/mu', { replace: true });
+    expect(testState.navigateMock).not.toHaveBeenCalledWith('/not-found', { replace: true });
+  });
+
+  it('restores cached feed rendering only after the pending post has painted', async () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+    testState.accountCommentIndex = '0';
+    testState.accountComments = [{}];
+    testState.post = { communityAddress: 'music-posting.eth', index: 0 };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+
+    await renderPendingPost();
+
+    expect(container.querySelector('[data-testid="post-view"]')).not.toBeNull();
+    expect(usePendingPostNavigationStore.getState().isNavigatingToPendingPost).toBe(true);
+    expect(frameCallbacks).toHaveLength(1);
+
+    act(() => frameCallbacks.shift()?.(0));
+    expect(usePendingPostNavigationStore.getState().isNavigatingToPendingPost).toBe(true);
+    expect(frameCallbacks).toHaveLength(1);
+
+    await act(async () => frameCallbacks.shift()?.(0));
+    expect(usePendingPostNavigationStore.getState().isNavigatingToPendingPost).toBe(false);
+
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
   it('redirects abandoned pending posts back to their board after the challenge closes', async () => {
     testState.accountCommentIndex = '0';
     testState.accountComments = [];
@@ -217,6 +351,7 @@ describe('PendingPost', () => {
     await renderPendingPost();
 
     expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { replace: true });
+    expect(container.querySelector('[data-testid="post-view"]')).toBeNull();
   });
 
   it('keeps a mid-retry pending post in place while the failed row is deleted and republished', async () => {

--- a/src/views/pending-post/__tests__/pending-post.test.tsx
+++ b/src/views/pending-post/__tests__/pending-post.test.tsx
@@ -356,6 +356,26 @@ describe('PendingPost', () => {
     expect(container.querySelector('[data-testid="post-view"]')).toBeNull();
   });
 
+  it('redirects addressless pending placeholders after their live handoff is cleared', async () => {
+    testState.accountCommentIndex = '0';
+    testState.accountComments = [{ index: 0 }];
+    testState.locationState = { boardPath: 'mu' };
+    testState.post = { index: 0 };
+    usePendingPostNavigationStore.getState().beginPendingPostNavigation(0);
+
+    await renderPendingPost();
+
+    expect(testState.navigateMock).not.toHaveBeenCalled();
+
+    usePendingPostNavigationStore.getState().clearPendingPostNavigation(0);
+    testState.navigateMock.mockClear();
+
+    await renderPendingPost();
+
+    expect(testState.navigateMock).toHaveBeenCalledWith('/mu', { replace: true });
+    expect(container.querySelector('[data-testid="post-view"]')).toBeNull();
+  });
+
   it('keeps a mid-retry pending post in place while the failed row is deleted and republished', async () => {
     testState.accountCommentIndex = '0';
     testState.accountComments = [];

--- a/src/views/pending-post/pending-post.tsx
+++ b/src/views/pending-post/pending-post.tsx
@@ -101,19 +101,27 @@ const PendingPost = () => {
       : undefined;
 
   useEffect(() => {
-    if (!isNavigatingToPendingPost) return;
+    if (!isNavigatingToPendingPost || pendingPostNavigationIndex !== normalizedAccountCommentIndex) return;
+
+    const navigationIndex = normalizedAccountCommentIndex;
+    const completeOwnedPendingNavigation = () => {
+      const pendingNavigationStore = usePendingPostNavigationStore.getState();
+      if (pendingNavigationStore.pendingPostNavigationIndex === null || pendingNavigationStore.pendingPostNavigationIndex === navigationIndex) {
+        pendingNavigationStore.completePendingPostNavigation();
+      }
+    };
 
     let secondFrameId: number | undefined;
     const firstFrameId = window.requestAnimationFrame(() => {
-      secondFrameId = window.requestAnimationFrame(() => usePendingPostNavigationStore.getState().completePendingPostNavigation());
+      secondFrameId = window.requestAnimationFrame(completeOwnedPendingNavigation);
     });
 
     return () => {
       window.cancelAnimationFrame(firstFrameId);
       if (typeof secondFrameId === 'number') window.cancelAnimationFrame(secondFrameId);
-      usePendingPostNavigationStore.getState().completePendingPostNavigation();
+      completeOwnedPendingNavigation();
     };
-  }, [isNavigatingToPendingPost]);
+  }, [isNavigatingToPendingPost, normalizedAccountCommentIndex]);
 
   useEffect(() => {
     // A retry deletes this pending row before republishing, briefly invalidating the index. Stay put;

--- a/src/views/pending-post/pending-post.tsx
+++ b/src/views/pending-post/pending-post.tsx
@@ -4,9 +4,11 @@ import { useAccountComment, useAccountComments } from '@bitsocial/bitsocial-reac
 import { useDirectories } from '../../hooks/use-directories';
 import { normalizeAccountCommentIndex } from '../../lib/utils/account-comment-index-utils';
 import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
+import { getPendingPostRouteBoardPath, getPendingPostRoutePost } from '../../lib/utils/pending-post-route-state';
 import { getBoardPath } from '../../lib/utils/route-utils';
 import useChallengesStore from '../../stores/use-challenges-store';
 import useFailedPostRetryStore from '../../stores/use-failed-post-retry-store';
+import usePendingPostNavigationStore from '../../stores/use-pending-post-navigation-store';
 import { Post } from '../post/post';
 
 type PendingAccountComment = {
@@ -15,7 +17,7 @@ type PendingAccountComment = {
 
 const hasPendingAccountCommentIndex = (accountComments: PendingAccountComment[] | undefined, accountCommentIndex: number) => {
   if (!accountComments || accountComments.length === 0) {
-    return true;
+    return false;
   }
 
   let hasExplicitIndices = false;
@@ -33,27 +35,31 @@ const hasPendingAccountCommentIndex = (accountComments: PendingAccountComment[] 
   return hasExplicitIndices ? false : accountCommentIndex < accountComments.length;
 };
 
-const getPendingRouteBoardPath = (state: unknown): string | undefined => {
-  if (!state || typeof state !== 'object') {
-    return undefined;
-  }
-
-  const boardPath = (state as { boardPath?: unknown }).boardPath;
-  return typeof boardPath === 'string' && boardPath ? boardPath : undefined;
-};
-
 const PendingPost = () => {
-  const { accountComments } = useAccountComments();
+  const { accountComments, state: accountCommentsState } = useAccountComments();
   const { accountCommentIndex } = useParams<{ accountCommentIndex?: string }>();
   const location = useLocation();
   const normalizedAccountCommentIndex = normalizeAccountCommentIndex(accountCommentIndex);
+  const isNavigatingToPendingPost = usePendingPostNavigationStore((state) => state.isNavigatingToPendingPost);
+  const pendingPostNavigationIndex = usePendingPostNavigationStore((state) => state.pendingPostNavigationIndex);
   const hasNormalizedAccountCommentIndex = normalizedAccountCommentIndex !== undefined;
-  const post = useAccountComment({ commentIndex: normalizedAccountCommentIndex });
+  const storedPost = useAccountComment({ commentIndex: normalizedAccountCommentIndex });
+  const routePost = getPendingPostRoutePost(location.state);
+  const storedPostCommunityAddress = getCommentCommunityAddress(storedPost);
+  const hasAddressableStoredPost = Boolean(storedPost?.cid || storedPostCommunityAddress);
+  const observedAddressableStoredPostIndexRef = useRef<number | undefined>(undefined);
+  const hadObservedAddressableStoredPost = observedAddressableStoredPostIndexRef.current === normalizedAccountCommentIndex;
+  const hasLiveOptimisticHandoff = pendingPostNavigationIndex === normalizedAccountCommentIndex;
+  const optimisticRoutePost =
+    hasLiveOptimisticHandoff && !hasAddressableStoredPost && !hadObservedAddressableStoredPost && routePost?.index === normalizedAccountCommentIndex
+      ? routePost
+      : undefined;
+  const post = hasAddressableStoredPost ? storedPost : optimisticRoutePost || storedPost;
   const postCommunityAddress = getCommentCommunityAddress(post);
   const hasAddressablePost = Boolean(post?.cid || postCommunityAddress);
   const navigate = useNavigate();
   const directories = useDirectories();
-  const routeBoardPath = getPendingRouteBoardPath(location.state);
+  const routeBoardPath = getPendingPostRouteBoardPath(location.state);
   const postBoardPath = postCommunityAddress ? getBoardPath(postCommunityAddress, directories) : undefined;
   const pendingBoardPath = postBoardPath || routeBoardPath;
   const hasActiveChallenge = useChallengesStore((state) => state.challenges.length > 0);
@@ -66,13 +72,45 @@ const PendingPost = () => {
   }, []);
 
   useEffect(() => {
+    if (hasAddressableStoredPost && typeof normalizedAccountCommentIndex === 'number') {
+      observedAddressableStoredPostIndexRef.current = normalizedAccountCommentIndex;
+      usePendingPostNavigationStore.getState().clearPendingPostHandoff(normalizedAccountCommentIndex);
+    }
+  }, [hasAddressableStoredPost, normalizedAccountCommentIndex]);
+
+  useEffect(() => {
     if (typeof normalizedAccountCommentIndex === 'number' && pendingBoardPath) {
       lastPendingBoardRef.current = { accountCommentIndex: normalizedAccountCommentIndex, boardPath: pendingBoardPath };
     }
   }, [normalizedAccountCommentIndex, pendingBoardPath]);
 
   const isValidAccountCommentIndex =
-    !accountCommentIndex || (hasNormalizedAccountCommentIndex && hasPendingAccountCommentIndex(accountComments, normalizedAccountCommentIndex));
+    !accountCommentIndex ||
+    (hasNormalizedAccountCommentIndex &&
+      (Boolean(optimisticRoutePost) || accountCommentsState !== 'succeeded' || hasPendingAccountCommentIndex(accountComments, normalizedAccountCommentIndex)));
+
+  const lastPendingBoard = lastPendingBoardRef.current;
+  const hasAuthoritativeMissingPost =
+    accountCommentsState === 'succeeded' && hasNormalizedAccountCommentIndex && !hasPendingAccountCommentIndex(accountComments, normalizedAccountCommentIndex);
+  const abandonedBoardPath =
+    !hasActiveChallenge && !hasAddressablePost && (hasAuthoritativeMissingPost || hadObservedAddressableStoredPost)
+      ? pendingBoardPath || (lastPendingBoard && lastPendingBoard.accountCommentIndex === normalizedAccountCommentIndex ? lastPendingBoard.boardPath : undefined)
+      : undefined;
+
+  useEffect(() => {
+    if (!isNavigatingToPendingPost) return;
+
+    let secondFrameId: number | undefined;
+    const firstFrameId = window.requestAnimationFrame(() => {
+      secondFrameId = window.requestAnimationFrame(() => usePendingPostNavigationStore.getState().completePendingPostNavigation());
+    });
+
+    return () => {
+      window.cancelAnimationFrame(firstFrameId);
+      if (typeof secondFrameId === 'number') window.cancelAnimationFrame(secondFrameId);
+      usePendingPostNavigationStore.getState().completePendingPostNavigation();
+    };
+  }, [isNavigatingToPendingPost]);
 
   useEffect(() => {
     // A retry deletes this pending row before republishing, briefly invalidating the index. Stay put;
@@ -80,13 +118,13 @@ const PendingPost = () => {
     if (isRetryingThisPendingPost) {
       return;
     }
+    if (hasActiveChallenge) {
+      return;
+    }
     if (!isValidAccountCommentIndex) {
-      const lastPendingBoard = lastPendingBoardRef.current;
-      const abandonedBoardPath =
-        !hasActiveChallenge && lastPendingBoard && lastPendingBoard.accountCommentIndex === normalizedAccountCommentIndex ? lastPendingBoard.boardPath : undefined;
       navigate(abandonedBoardPath ? `/${abandonedBoardPath}` : '/not-found', { replace: true });
     }
-  }, [hasActiveChallenge, isRetryingThisPendingPost, isValidAccountCommentIndex, navigate, normalizedAccountCommentIndex]);
+  }, [abandonedBoardPath, hasActiveChallenge, isRetryingThisPendingPost, isValidAccountCommentIndex, navigate]);
 
   useEffect(() => {
     if (post?.cid && postBoardPath) {
@@ -99,15 +137,13 @@ const PendingPost = () => {
       return;
     }
 
-    const lastPendingBoard = lastPendingBoardRef.current;
-    const abandonedBoardPath =
-      !hasActiveChallenge && lastPendingBoard && lastPendingBoard.accountCommentIndex === normalizedAccountCommentIndex ? lastPendingBoard.boardPath : undefined;
     if (abandonedBoardPath) {
+      usePendingPostNavigationStore.getState().clearPendingPostNavigation(normalizedAccountCommentIndex);
       navigate(`/${abandonedBoardPath}`, { replace: true });
     }
-  }, [hasActiveChallenge, hasAddressablePost, isRetryingThisPendingPost, isValidAccountCommentIndex, navigate, normalizedAccountCommentIndex]);
+  }, [abandonedBoardPath, hasAddressablePost, isRetryingThisPendingPost, isValidAccountCommentIndex, navigate, normalizedAccountCommentIndex]);
 
-  return <Post post={post} />;
+  return abandonedBoardPath ? null : <Post post={post} />;
 };
 
 export default PendingPost;

--- a/src/views/pending-post/pending-post.tsx
+++ b/src/views/pending-post/pending-post.tsx
@@ -48,7 +48,8 @@ const PendingPost = () => {
   const storedPostCommunityAddress = getCommentCommunityAddress(storedPost);
   const hasAddressableStoredPost = Boolean(storedPost?.cid || storedPostCommunityAddress);
   const observedAddressableStoredPostIndexRef = useRef<number | undefined>(undefined);
-  const hadObservedAddressableStoredPost = observedAddressableStoredPostIndexRef.current === normalizedAccountCommentIndex;
+  const hadObservedAddressableStoredPost =
+    typeof normalizedAccountCommentIndex === 'number' && observedAddressableStoredPostIndexRef.current === normalizedAccountCommentIndex;
   const hasLiveOptimisticHandoff = pendingPostNavigationIndex === normalizedAccountCommentIndex;
   const optimisticRoutePost =
     hasLiveOptimisticHandoff && !hasAddressableStoredPost && !hadObservedAddressableStoredPost && routePost?.index === normalizedAccountCommentIndex

--- a/src/views/pending-post/pending-post.tsx
+++ b/src/views/pending-post/pending-post.tsx
@@ -154,7 +154,7 @@ const PendingPost = () => {
     }
   }, [abandonedBoardPath, hasAddressablePost, isRetryingThisPendingPost, isValidAccountCommentIndex, navigate, normalizedAccountCommentIndex]);
 
-  return abandonedBoardPath ? null : <Post post={post} />;
+  return abandonedBoardPath ? null : <Post key={normalizedAccountCommentIndex} post={post} />;
 };
 
 export default PendingPost;

--- a/src/views/pending-post/pending-post.tsx
+++ b/src/views/pending-post/pending-post.tsx
@@ -92,7 +92,9 @@ const PendingPost = () => {
 
   const lastPendingBoard = lastPendingBoardRef.current;
   const hasAuthoritativeMissingPost =
-    accountCommentsState === 'succeeded' && hasNormalizedAccountCommentIndex && !hasPendingAccountCommentIndex(accountComments, normalizedAccountCommentIndex);
+    accountCommentsState === 'succeeded' &&
+    hasNormalizedAccountCommentIndex &&
+    (!hasPendingAccountCommentIndex(accountComments, normalizedAccountCommentIndex) || (!hasLiveOptimisticHandoff && !hasAddressableStoredPost));
   const abandonedBoardPath =
     !hasActiveChallenge && !hasAddressablePost && (hasAuthoritativeMissingPost || hadObservedAddressableStoredPost)
       ? pendingBoardPath || (lastPendingBoard && lastPendingBoard.accountCommentIndex === normalizedAccountCommentIndex ? lastPendingBoard.boardPath : undefined)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "5chan@workspace:."
   dependencies:
     "@bbob/parser": "npm:4.3.1"
-    "@bitsocial/bitsocial-react-hooks": "npm:0.1.33"
+    "@bitsocial/bitsocial-react-hooks": "npm:0.1.34"
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@capacitor/android": "npm:7.4.5"
     "@capacitor/app": "npm:7.0.1"
@@ -1582,9 +1582,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bitsocial-react-hooks@npm:0.1.33":
-  version: 0.1.33
-  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.33"
+"@bitsocial/bitsocial-react-hooks@npm:0.1.34":
+  version: 0.1.34
+  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.34"
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@pkcprotocol/pkc-js": "npm:0.0.72"
@@ -1603,7 +1603,7 @@ __metadata:
     zustand: "npm:4.5.7"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/b14c1b5d3d225144b23909479f6f4596a9f460a763576858ea534581b73ee1255da066fb255392876147692c90a6978b1135f218258b3ce21cb0dcd9c04aa582
+  checksum: 10c0/3c56c97739f4d5447f34c76886c13dedd104d0596df705ee9988dbba8a25fc7a2f5e718ca65dd3904dc440d8fa4f3c98e66390923bf6307368b24937dbc95f7e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- render a provisional pending thread synchronously when publishing starts
- preserve the mounted board shell and cached feed while entering and leaving the pending route
- return cleanly to the board when a challenge is abandoned or an optimistic post never persists
- consume `@bitsocial/bitsocial-react-hooks` 0.1.34 for the pre-persistence pending-comment callback
- cover corrected indices, `nonoko`, stale route state, publication errors, and late callback races

## Verification

- `yarn test` (169 files, 1,409 tests)
- `yarn build`
- `yarn lint`
- `yarn type-check`
- `yarn knip`
- `yarn doctor --scope changed --base origin/master` (one reviewed warning for intentional synchronous navigation)
- fresh private desktop and mobile publishing/abandon flows in Chrome, Firefox, and WebKit
- throttled Chromium mid-tier CPU/network publishing/abandon flow

## Issue

Pending threads should appear immediately without remounting the board shell or flashing an invalid route during publish and abandon transitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core publish-to-route flow, synchronous navigation, and several redirect/race paths; behavior is heavily tested but regressions could affect posting, pending URLs, and settings navigation.
> 
> **Overview**
> Publishing now **navigates to `/pending/:index` as soon as the hooks layer creates a pending comment** (`onPendingComment` in `@bitsocial/bitsocial-react-hooks` 0.1.34), using `flushSync` and route state (`boardPath`, `pendingPost`) so the provisional thread can render before the account store catches up.
> 
> A new **`usePendingPostNavigationStore`** coordinates the handoff: the board layout keeps chrome and **hides (not unmounts) the cached feed** via React `Activity` until the pending view has painted, then restores it after a double `requestAnimationFrame`. **Board header, boards bar, theme, and post form** resolve community context from route `pendingPost` when the account row is not addressable yet; **settings links** forward `location.state` so pending context survives settings open/close.
> 
> **`PendingPost`** prefers stored comments when available, otherwise shows an optimistic route fallback only while a live handoff matches the index; it tightens invalid-index handling, redirects abandoned or never-persisted posts back to the board, and avoids stale route state after reload. **`usePublishPost` / `PostForm`** add abandon, publish-error, and pending callbacks with guards so late errors or abandonments do not clear a newer handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a6eb1b49f3a384cba74274b2688a9c1d76e001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother navigation and optimistic display for posts while publishing.
  * Preserves board context, cached feeds, mobile navigation, and themes during pending-post navigation.
  * Retains navigation context when moving through settings.

* **Bug Fixes**
  * Improved handling of abandoned posts, publishing errors, failed redirects, and missing account data.
  * Restores cached feed content after navigation.
  * Prevents stale navigation state and incomplete loading from disrupting newer actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->