### PR TITLE
chore(deps): upgrade bitsocial-react-hooks to 0.1.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "@bbob/parser": "4.3.1",
-    "@bitsocial/bitsocial-react-hooks": "0.1.34",
+    "@bitsocial/bitsocial-react-hooks": "0.1.36",
     "@bitsocial/bso-resolver": "0.0.10",
     "@capacitor/app": "7.0.1",
     "@capacitor/browser": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "5chan@workspace:."
   dependencies:
     "@bbob/parser": "npm:4.3.1"
-    "@bitsocial/bitsocial-react-hooks": "npm:0.1.34"
+    "@bitsocial/bitsocial-react-hooks": "npm:0.1.36"
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@capacitor/android": "npm:7.4.5"
     "@capacitor/app": "npm:7.0.1"
@@ -1582,12 +1582,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bitsocial-react-hooks@npm:0.1.34":
-  version: 0.1.34
-  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.34"
+"@bitsocial/bitsocial-react-hooks@npm:0.1.36":
+  version: 0.1.36
+  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.36"
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.10"
-    "@pkcprotocol/pkc-js": "npm:0.0.72"
+    "@pkcprotocol/pkc-js": "npm:0.0.78"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     assert: "npm:2.1.0"
     ethers: "npm:5.8.0"
@@ -1603,7 +1603,7 @@ __metadata:
     zustand: "npm:4.5.7"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/3c56c97739f4d5447f34c76886c13dedd104d0596df705ee9988dbba8a25fc7a2f5e718ca65dd3904dc440d8fa4f3c98e66390923bf6307368b24937dbc95f7e
+  checksum: 10c0/282be80dcc09aa3b3c0ff7b6308a9fbb30ba2ccba8e67970a5d117cc79b14b11c8c7ecbc44b8a5b22b0d7f29f35a1ab109258a5229b05da5ccdf9ec8f261d95c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `@bitsocial/bitsocial-react-hooks` from `0.1.34` to `0.1.36`
- consume the published npm package directly with its `pkc-js` 0.0.78 dependency

## Verification

- `corepack yarn install`
- `corepack yarn prettier`
- `corepack yarn build`
- `corepack yarn lint`
- `corepack yarn type-check`
- `corepack yarn test --run` (169 files passed; 1,419 tests passed)
- `corepack yarn knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the primary data/PKC integration layer (bitsocial-react-hooks and pkc-js) with no code changes; behavior shifts depend entirely on the upstream package release.
> 
> **Overview**
> Bumps **`@bitsocial/bitsocial-react-hooks`** from **0.1.34** to **0.1.36** in `package.json`, with the matching **`yarn.lock`** refresh.
> 
> The new hooks release pulls **`@pkcprotocol/pkc-js` 0.0.78** (replacing 0.0.72 inside the hooks subtree), which lines up with the app’s existing direct dependency and Yarn resolution on **0.0.78**. No application source changes—only dependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4305ae0453030b3c78d22957159f464b2592bb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bitsocial React Hooks package to a newer version, bringing the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->