### PR TITLE
test(bitsocial): isolate utility mocks from account store

### DIFF
--- a/src/lib/utils/__tests__/pattern-utils.test.ts
+++ b/src/lib/utils/__tests__/pattern-utils.test.ts
@@ -5,8 +5,8 @@ const testState = vi.hoisted(() => ({
   communities: {} as Record<string, { roles?: Record<string, { role?: string }> }>,
 }));
 
-vi.mock('@bitsocial/bitsocial-react-hooks/dist/stores/communities', () => ({
-  default: {
+vi.mock('../../bitsocial-internals/stores', () => ({
+  communitiesStore: {
     getState: () => ({
       communities: testState.communities,
     }),

--- a/src/lib/utils/__tests__/thread-refresh-cache-utils.test.ts
+++ b/src/lib/utils/__tests__/thread-refresh-cache-utils.test.ts
@@ -10,8 +10,8 @@ const testState = vi.hoisted(() => ({
   repliesPagesSetStateMock: vi.fn(),
 }));
 
-vi.mock('@bitsocial/bitsocial-react-hooks/dist/lib/localforage-lru', () => ({
-  default: {
+vi.mock('../../bitsocial-internals/utils', () => ({
+  localForageLru: {
     createInstance: ({ name }: { name: string }) => {
       if (name === 'bitsocialReactHooks-comments') {
         return {
@@ -25,8 +25,8 @@ vi.mock('@bitsocial/bitsocial-react-hooks/dist/lib/localforage-lru', () => ({
   },
 }));
 
-vi.mock('@bitsocial/bitsocial-react-hooks/dist/stores/replies-pages', () => ({
-  default: {
+vi.mock('../../bitsocial-internals/stores', () => ({
+  repliesPagesStore: {
     getState: () => testState.repliesPagesState,
     setState: (updater: (state: typeof testState.repliesPagesState) => Partial<typeof testState.repliesPagesState>) => {
       testState.repliesPagesSetStateMock(updater);


### PR DESCRIPTION
## Summary

- mock 5chan's approved Bitsocial adapter modules in the two affected utility tests
- avoid evaluating the unrelated account store and leaving its async initializer alive past jsdom teardown
- keep 5chan pinned directly to `@bitsocial/bitsocial-react-hooks` 0.1.36

## Evidence

- the post-merge 0.1.36 workflow failed twice after all 1,419 assertions passed, with `window is not defined` from the account-store initializer during jsdom teardown
- the affected tests predate the adapter boundary and still mocked the old upstream module paths

## Verification

- focused tests with async-leak detection passed twice (2 files; 8 tests)
- `corepack yarn prettier`
- `corepack yarn build`
- `corepack yarn lint`
- `corepack yarn type-check`
- `corepack yarn test --run` (169 files passed; 1,419 tests passed)
- `corepack yarn test:leaks` (169 files and 1,419 tests passed; no Bitsocial account-store leak)
- `corepack yarn knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock path changes with no production behavior changes; intended to fix CI teardown flakes.
> 
> **Overview**
> Updates **`pattern-utils`** and **`thread-refresh-cache-utils`** Vitest mocks so they stub 5chan’s **`bitsocial-internals`** adapter modules instead of deep **`@bitsocial/bitsocial-react-hooks/dist/...`** paths.
> 
> **`pattern-utils.test.ts`** now mocks **`communitiesStore`** from **`bitsocial-internals/stores`**. **`thread-refresh-cache-utils.test.ts`** mocks **`localForageLru`** from **`bitsocial-internals/utils`** and **`repliesPagesStore`** from **`bitsocial-internals/stores`**, matching what the utilities import. This keeps tests from evaluating unrelated upstream store code (including the account store async initializer) that was surfacing **`window is not defined`** during jsdom teardown after assertions passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2fe4c33f950f886f6f1c36c3e9b33f2995003c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mocks to use the current internal store and utility interfaces.
  * Preserved existing mock behavior while improving test compatibility with the application’s module structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->