### PR TITLE
fix(thread): preserve canonical replies for owned posts

### DIFF
--- a/src/views/post/__tests__/post.test.tsx
+++ b/src/views/post/__tests__/post.test.tsx
@@ -229,6 +229,7 @@ vi.mock('../../../components/post-desktop/post-desktop', () => ({
         'data-author-short-address': post?.author?.shortAddress || '',
         'data-number': post?.number === undefined ? '' : String(post.number),
         'data-pending-approval': post?.pendingApproval === undefined ? '' : String(post.pendingApproval),
+        'data-reply-count': post?.replyCount === undefined ? '' : String(post.replyCount),
         'data-replies': replyPaginationOverride?.replies?.map((reply) => reply.cid).join(',') || '',
         'data-roles-present': String(roles !== undefined),
         'data-transfer-enabled': String(typeof onTransfer === 'function'),
@@ -263,6 +264,7 @@ vi.mock('../../../components/post-mobile/post-mobile', () => ({
         'data-author-short-address': post?.author?.shortAddress || '',
         'data-number': post?.number === undefined ? '' : String(post.number),
         'data-pending-approval': post?.pendingApproval === undefined ? '' : String(post.pendingApproval),
+        'data-reply-count': post?.replyCount === undefined ? '' : String(post.replyCount),
         'data-replies': replyPaginationOverride?.replies?.map((reply) => reply.cid).join(',') || '',
         'data-roles-present': String(roles !== undefined),
         'data-transfer-enabled': String(typeof onTransfer === 'function'),
@@ -666,7 +668,7 @@ describe('Post', () => {
     expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
 
-  it('overlays local account comments on thread pages so author controls receive account author data', async () => {
+  it('keeps current thread data while restoring the local account author', async () => {
     testState.commentsByCid = {
       'owned-cid': {
         cid: 'owned-cid',
@@ -688,6 +690,7 @@ describe('Post', () => {
           address: 'account-author',
         },
         content: 'local body',
+        replyCount: 0,
         communityAddress: 'music-posting.eth',
         title: 'Local thread',
       },
@@ -698,7 +701,9 @@ describe('Post', () => {
     const desktopPresenter = container.querySelector('[data-testid="post-desktop"]');
     expect(desktopPresenter?.getAttribute('data-author-address')).toBe('account-author');
     expect(desktopPresenter?.getAttribute('data-number')).toBe('14');
+    expect(desktopPresenter?.getAttribute('data-reply-count')).toBe('3');
     expect(container.querySelector('[data-testid="thread-footer-first-row"]')?.textContent).toBe('owned-cid:14:music-posting.eth:false');
+    expect(document.title).toBe('/mu/ - Remote thread... - 5chan');
   });
 
   it('restores the active account author when a mapped account comment only has anonymous author metadata', async () => {

--- a/src/views/post/__tests__/post.test.tsx
+++ b/src/views/post/__tests__/post.test.tsx
@@ -673,6 +673,7 @@ describe('Post', () => {
       'owned-loading-cid': {
         cid: 'owned-loading-cid',
         state: 'updating',
+        replyCount: 0,
         communityAddress: 'music-posting.eth',
       },
     };

--- a/src/views/post/__tests__/post.test.tsx
+++ b/src/views/post/__tests__/post.test.tsx
@@ -668,6 +668,38 @@ describe('Post', () => {
     expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
 
+  it('keeps the local account comment while the canonical comment is only a loading shell', async () => {
+    testState.commentsByCid = {
+      'owned-loading-cid': {
+        cid: 'owned-loading-cid',
+        state: 'updating',
+        communityAddress: 'music-posting.eth',
+      },
+    };
+    testState.accountCommentsByCid = {
+      'owned-loading-cid': {
+        cid: 'owned-loading-cid',
+        postCid: 'owned-loading-cid',
+        author: {
+          address: 'account-author',
+        },
+        content: 'local body',
+        number: 13,
+        replyCount: 0,
+        communityAddress: 'music-posting.eth',
+        title: 'Local thread',
+      },
+    };
+
+    await renderPostPage('/mu/thread/owned-loading-cid');
+
+    const desktopPresenter = container.querySelector('[data-testid="post-desktop"]');
+    expect(desktopPresenter?.getAttribute('data-author-address')).toBe('account-author');
+    expect(desktopPresenter?.getAttribute('data-number')).toBe('13');
+    expect(desktopPresenter?.getAttribute('data-reply-count')).toBe('0');
+    expect(document.title).toBe('/mu/ - Local thread... - 5chan');
+  });
+
   it('keeps current thread data while restoring the local account author', async () => {
     testState.commentsByCid = {
       'owned-cid': {

--- a/src/views/post/post.tsx
+++ b/src/views/post/post.tsx
@@ -92,7 +92,6 @@ const mergeCommentFallback = (comment: CommentWithRefresh | undefined, fallback:
   const hasRenderableData =
     comment.timestamp !== undefined ||
     comment.number !== undefined ||
-    comment.replyCount !== undefined ||
     !!comment.content ||
     !!comment.title ||
     !!comment.link ||

--- a/src/views/post/post.tsx
+++ b/src/views/post/post.tsx
@@ -146,9 +146,9 @@ const mergeLocalAccountComment = (comment: CommentWithRefresh | undefined, accou
   if (!comment) return accountComment;
   if (comment.cid && accountComment.cid && comment.cid !== accountComment.cid) return comment;
 
-  // The persisted account copy can lag mutable fields such as replies; only its
-  // author identity is needed to restore owner controls on the canonical comment.
-  return mergeLocalCommentAuthor(comment, accountComment);
+  // Use the persisted account copy only while the canonical comment is a loading
+  // shell, then retain only its author identity once canonical data is renderable.
+  return mergeLocalCommentAuthor(mergeCommentFallback(comment, accountComment), accountComment);
 };
 
 // useComment may not return cached feed data immediately due to its updatedAt comparison logic.

--- a/src/views/post/post.tsx
+++ b/src/views/post/post.tsx
@@ -146,19 +146,14 @@ const mergeLocalAccountComment = (comment: CommentWithRefresh | undefined, accou
   if (!comment) return accountComment;
   if (comment.cid && accountComment.cid && comment.cid !== accountComment.cid) return comment;
 
-  const mergedComment = mergeDefinedFields(comment, accountComment) ?? comment;
-  // mergeDefinedFields replaces author wholesale, so re-merge author field-wise from the
-  // published comment (mergeLocalCommentAuthor also preserves the published User ID)
-  const commentWithMergedAuthor = mergeLocalCommentAuthor(comment, accountComment);
-  return {
-    ...mergedComment,
-    ...(commentWithMergedAuthor?.author ? { author: commentWithMergedAuthor.author } : {}),
-  };
+  // The persisted account copy can lag mutable fields such as replies; only its
+  // author identity is needed to restore owner controls on the canonical comment.
+  return mergeLocalCommentAuthor(comment, accountComment);
 };
 
 // useComment may not return cached feed data immediately due to its updatedAt comparison logic.
 // This hook falls back to the communities pages store and then overlays a matching
-// local account comment so author controls keep working after publish navigation.
+// local account author so author controls keep working after publish navigation.
 const useCommentWithFeedCache = (options: { commentCid: string | undefined; autoUpdate?: boolean; community?: CommunityIdentifier }): CommentWithRefresh | undefined => {
   const comment = useComment(options);
   const cachedComment = useCommunitiesPagesStore((state) => state.comments[options?.commentCid || '']);


### PR DESCRIPTION
## Summary

- preserve freshly fetched thread data when the current account owns the post
- overlay only the local author identity needed for owner controls
- add a regression test covering a stale local `replyCount: 0` against a canonical thread with three replies

## Root cause

The thread page merged the entire persisted account comment over the canonical comment. When that local owner copy lagged behind with zero replies, it replaced the freshly fetched `replyCount`, title, and reply metadata after every Update or hard refresh. Private windows did not have that persisted owner copy, so they rendered the canonical replies correctly.

## User impact

Owned threads now retain current canonical replies and metadata while edit/delete controls continue to receive the local account author identity.

## Verification

- reproduced the production profile showing no replies and `0 / 0 / 1` while the protocol returned three replies
- imported the affected account into the patched local build and confirmed replies 990, 991, and 992 remained visible initially, after Update, and after a hard reload
- regression test failed before the implementation change (`expected 3, received 0`) and passes afterward
- `corepack yarn test`
- `corepack yarn build`
- `corepack yarn lint`
- `corepack yarn type-check`
- `corepack yarn doctor --scope changed --base master`
- `corepack yarn prettier`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread-page comment merging for account-owned posts; wrong fallback rules could hide replies or break owner controls, but scope is limited to `post.tsx` merge helpers with targeted regression tests.
> 
> **Overview**
> Fixes owned thread pages showing **0 replies** after refresh when a stale persisted account copy still had `replyCount: 0`.
> 
> **Thread merge logic** (`mergeLocalAccountComment`): Stops blanket-merging the local account comment over the canonical one. The account copy is used only while the canonical comment is a loading shell (`mergeCommentFallback`); once canonical data is renderable, only **local author identity** is overlaid so edit/delete controls still work. `replyCount` was removed from the “renderable” heuristic so reply count alone doesn’t block treating a shell as non-renderable in that path.
> 
> **Tests**: Desktop/mobile mocks expose `data-reply-count`; new case for loading-shell + local account data; regression asserts canonical `replyCount: 3` and remote title win when local account has `replyCount: 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c7b13d2918bd16a139706b5ffd3d3b1ff7197b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved canonical comment details, including remote reply counts and titles, when restoring local account authorship.
  * Prevented local account data from unintentionally overwriting updated comment information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->