### PR TITLE
fix(settings): show settings sections instantly when expanded

### DIFF
--- a/src/components/settings-modal/__tests__/lazy-section.test.tsx
+++ b/src/components/settings-modal/__tests__/lazy-section.test.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { createElement, Suspense } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import LazySection, { createSectionLoader } from '../lazy-section';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const act = (React as { act?: (cb: () => void | Promise<void>) => void | Promise<void> }).act as (cb: () => void | Promise<void>) => void | Promise<void>;
+
+const Section = () => <div data-testid='section'>section</div>;
+
+let root: Root;
+let container: HTMLDivElement;
+
+const renderSection = (load: () => Promise<{ default: React.ComponentType }>) =>
+  createElement(Suspense, { fallback: createElement('div', { 'data-testid': 'fallback' }) }, createElement(LazySection, { load }));
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('createSectionLoader', () => {
+  it('reuses the same import promise', () => {
+    let imports = 0;
+    const load = createSectionLoader(async () => {
+      imports++;
+      return { default: Section };
+    });
+
+    expect(load()).toBe(load());
+    expect(imports).toBe(1);
+  });
+
+  it('renders a preloaded section without showing the suspense fallback', async () => {
+    const load = createSectionLoader(async () => ({ default: Section }));
+
+    await load();
+
+    // A synchronous render: a section whose chunk is already loaded has to
+    // render in the same commit, otherwise expanding it lags behind the click.
+    act(() => root.render(renderSection(load)));
+
+    expect(container.querySelector('[data-testid="fallback"]')).toBeNull();
+    expect(container.querySelector('[data-testid="section"]')).not.toBeNull();
+  });
+
+  it('suspends while the section is still loading', async () => {
+    let resolveImport: (module: { default: React.ComponentType }) => void = () => {};
+    const load = createSectionLoader(
+      () =>
+        new Promise<{ default: React.ComponentType }>((resolve) => {
+          resolveImport = resolve;
+        }),
+    );
+
+    await act(async () => {
+      root.render(renderSection(load));
+    });
+
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+
+    await act(async () => {
+      resolveImport({ default: Section });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(container.querySelector('[data-testid="section"]')).not.toBeNull();
+  });
+});

--- a/src/components/settings-modal/interface-settings/interface-settings.tsx
+++ b/src/components/settings-modal/interface-settings/interface-settings.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, Suspense } from 'react';
+import { memo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './interface-settings.module.css';
 import capitalize from 'lodash/capitalize';
@@ -6,10 +6,17 @@ import useExpandedMediaStore from '../../../stores/use-expanded-media-store';
 import useFeedViewSettingsStore from '../../../stores/use-feed-view-settings-store';
 import Version from '../../version';
 import StyleSelector from '../../style-selector/style-selector';
+import LazySection, { createSectionLoader } from '../lazy-section';
 import { INTERFACE_LANGUAGE_STORAGE_KEY, SUPPORTED_INTERFACE_LANGUAGES } from '../../../lib/constants';
 
 const shouldRenderAppUpdateSetting = import.meta.env.VITE_APP_DISTRIBUTION !== 'fdroid';
-const AppUpdateSetting = shouldRenderAppUpdateSetting ? lazy(() => import('./app-update-setting')) : null;
+const loadAppUpdateSetting = createSectionLoader(() => import('./app-update-setting'));
+
+// This module is itself preloaded while settings is open, so start the update
+// setting's chunk here rather than when the interface section first renders.
+if (shouldRenderAppUpdateSetting) {
+  loadAppUpdateSetting();
+}
 
 const InterfaceLanguage = () => {
   const { i18n } = useTranslation();
@@ -44,9 +51,9 @@ const InterfaceSettings = () => {
       <div className={styles.version}>
         {capitalize(t('version'))}: <Version />
       </div>
-      {AppUpdateSetting && (
+      {shouldRenderAppUpdateSetting && (
         <Suspense fallback={null}>
-          <AppUpdateSetting />
+          <LazySection load={loadAppUpdateSetting} />
         </Suspense>
       )}
       <div className={styles.setting}>

--- a/src/components/settings-modal/lazy-section.tsx
+++ b/src/components/settings-modal/lazy-section.tsx
@@ -1,0 +1,52 @@
+import { ComponentType, use } from 'react';
+
+type SectionModule = { default: ComponentType };
+
+/** The fields React reads off a promise passed to `use()`. */
+type TrackedPromiseState = {
+  reason?: unknown;
+  status?: 'fulfilled' | 'rejected';
+  value?: SectionModule;
+};
+
+export type SectionLoader = () => Promise<SectionModule>;
+
+/**
+ * Caches a settings section's dynamic import and tags the promise with the
+ * state `use()` reads, so a section whose chunk is already loaded renders in
+ * the same commit as the click that expanded it. `lazy()` cannot do that: it
+ * only resolves its payload the first time the section renders, and React
+ * schedules that resolution as a separate task, which left every section
+ * visibly loading after the click even once its chunk was cached.
+ */
+export const createSectionLoader = (load: () => Promise<SectionModule>): SectionLoader => {
+  let tracked: Promise<SectionModule> | undefined;
+
+  return () => {
+    if (!tracked) {
+      const pending = load();
+      const trackedState = pending as Promise<SectionModule> & TrackedPromiseState;
+      pending.then(
+        (module) => {
+          trackedState.status = 'fulfilled';
+          trackedState.value = module;
+        },
+        (reason) => {
+          trackedState.status = 'rejected';
+          trackedState.reason = reason;
+        },
+      );
+      tracked = pending;
+    }
+
+    return tracked;
+  };
+};
+
+/** Renders a code split section, suspending only while its chunk is still loading. */
+const LazySection = ({ load }: { load: SectionLoader }) => {
+  const { default: Section } = use(load());
+  return <Section />;
+};
+
+export default LazySection;

--- a/src/components/settings-modal/settings-modal.tsx
+++ b/src/components/settings-modal/settings-modal.tsx
@@ -1,22 +1,34 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccount, usePkcRpcSettings } from '@bitsocial/bitsocial-react-hooks';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import styles from './settings-modal.module.css';
+import LazySection, { createSectionLoader } from './lazy-section';
 import { P2P_STATS_SECTION_ID, shouldShowP2PSettingsSection } from '../../lib/p2p-runtime';
 import { getReviewableSettingsUpgrades, getSettingsUpgradeKey, type SettingsUpgradeAccount } from '../../lib/settings-upgrades';
 import useSettingsUpgradeReviewStore from '../../stores/use-settings-upgrade-review-store';
 import { getSettingsSectionPath } from '../../lib/utils/route-utils';
 
-const AccountSettings = lazy(() => import('./account-settings/account-settings'));
-const CryptoAddressSetting = lazy(() => import('./crypto-address-setting/crypto-address-setting'));
-const CryptoWalletsSetting = lazy(() => import('./crypto-wallets-setting/crypto-wallets-setting'));
-const InterfaceSettings = lazy(() => import('./interface-settings/interface-settings'));
-const MediaHostingSettings = lazy(() => import('./media-hosting-settings/media-hosting-settings'));
-const AdvancedSettings = lazy(() => import('./advanced-settings/advanced-settings'));
-const SubscriptionsSetting = lazy(() => import('./subscriptions-setting/subscriptions-setting'));
-const TrustedBoardLinksSetting = lazy(() => import('./trusted-board-links-setting/trusted-board-links-setting'));
-const P2PStatsSettings = lazy(() => import('./p2p-stats-settings/p2p-stats-settings'));
+const loadAccountSettings = createSectionLoader(() => import('./account-settings/account-settings'));
+const loadCryptoAddressSetting = createSectionLoader(() => import('./crypto-address-setting/crypto-address-setting'));
+const loadCryptoWalletsSetting = createSectionLoader(() => import('./crypto-wallets-setting/crypto-wallets-setting'));
+const loadInterfaceSettings = createSectionLoader(() => import('./interface-settings/interface-settings'));
+const loadMediaHostingSettings = createSectionLoader(() => import('./media-hosting-settings/media-hosting-settings'));
+const loadAdvancedSettings = createSectionLoader(() => import('./advanced-settings/advanced-settings'));
+const loadSubscriptionsSetting = createSectionLoader(() => import('./subscriptions-setting/subscriptions-setting'));
+const loadTrustedBoardLinksSetting = createSectionLoader(() => import('./trusted-board-links-setting/trusted-board-links-setting'));
+const loadP2PStatsSettings = createSectionLoader(() => import('./p2p-stats-settings/p2p-stats-settings'));
+
+const alwaysVisibleSectionLoaders = [
+  loadInterfaceSettings,
+  loadMediaHostingSettings,
+  loadAccountSettings,
+  loadCryptoAddressSetting,
+  loadCryptoWalletsSetting,
+  loadSubscriptionsSetting,
+  loadTrustedBoardLinksSetting,
+  loadAdvancedSettings,
+];
 
 const allSectionIds = [
   'interface-settings',
@@ -58,6 +70,17 @@ const SettingsModal = () => {
     const newPath = pathname.replace(/\/settings$/, '');
     navigate(getSettingsSectionPath(newPath, null, search), { state });
   }, [pathname, navigate, search, state]);
+
+  const showsP2PStatsSection = sectionIds.includes(P2P_STATS_SECTION_ID);
+
+  // Fetch every section chunk as soon as settings opens, so expanding a section
+  // renders it in the same commit as the click instead of waiting on a request.
+  useEffect(() => {
+    alwaysVisibleSectionLoaders.forEach((load) => load());
+    if (showsP2PStatsSection) {
+      loadP2PStatsSettings();
+    }
+  }, [showsP2PStatsSection]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -167,7 +190,7 @@ const SettingsModal = () => {
         </div>
         {showInterfaceSettings && (
           <Suspense fallback={null}>
-            <InterfaceSettings />
+            <LazySection load={loadInterfaceSettings} />
           </Suspense>
         )}
         <div id='media-hosting-settings' className={`${styles.setting} ${styles.category}`}>
@@ -178,7 +201,7 @@ const SettingsModal = () => {
         </div>
         {showMediaHostingSettings && (
           <Suspense fallback={null}>
-            <MediaHostingSettings />
+            <LazySection load={loadMediaHostingSettings} />
           </Suspense>
         )}
         <div id='account-settings' className={`${styles.setting} ${styles.category}`}>
@@ -190,15 +213,15 @@ const SettingsModal = () => {
         {showAccountSettings && (
           <>
             <Suspense fallback={null}>
-              <AccountSettings />
+              <LazySection load={loadAccountSettings} />
             </Suspense>
             <div className={styles.subSectionHeader}>{t('crypto_address')}</div>
             <Suspense fallback={null}>
-              <CryptoAddressSetting />
+              <LazySection load={loadCryptoAddressSetting} />
             </Suspense>
             <div className={styles.subSectionHeader}>{t('crypto_wallets')}</div>
             <Suspense fallback={null}>
-              <CryptoWalletsSetting />
+              <LazySection load={loadCryptoWalletsSetting} />
             </Suspense>
           </>
         )}
@@ -210,7 +233,7 @@ const SettingsModal = () => {
         </div>
         {showSubscriptionsSettings && (
           <Suspense fallback={null}>
-            <SubscriptionsSetting />
+            <LazySection load={loadSubscriptionsSetting} />
           </Suspense>
         )}
         <div id='board-link-permissions-settings' className={`${styles.setting} ${styles.category}`}>
@@ -221,7 +244,7 @@ const SettingsModal = () => {
         </div>
         {showBoardLinkPermissionsSettings && (
           <Suspense fallback={null}>
-            <TrustedBoardLinksSetting />
+            <LazySection load={loadTrustedBoardLinksSetting} />
           </Suspense>
         )}
         <div id='advanced-settings' className={`${styles.setting} ${styles.category}`}>
@@ -232,10 +255,10 @@ const SettingsModal = () => {
         </div>
         {showAdvancedSettings && (
           <Suspense fallback={null}>
-            <AdvancedSettings />
+            <LazySection load={loadAdvancedSettings} />
           </Suspense>
         )}
-        {sectionIds.includes(P2P_STATS_SECTION_ID) && (
+        {showsP2PStatsSection && (
           <>
             <div id={P2P_STATS_SECTION_ID} className={`${styles.setting} ${styles.category}`}>
               <button type='button' className={styles.categoryButton} onClick={() => handleCategoryClick(P2P_STATS_SECTION_ID)}>
@@ -245,7 +268,7 @@ const SettingsModal = () => {
             </div>
             {showP2PStatsSettings && (
               <Suspense fallback={null}>
-                <P2PStatsSettings />
+                <LazySection load={loadP2PStatsSettings} />
               </Suspense>
             )}
           </>


### PR DESCRIPTION
## Problem

On a cold cache (new private window → community → Settings → expand), every settings section appeared blank for a moment before filling in.

It is not the chunk download. Measured in a fresh Chromium session: all section chunks were fully cached **before** the click, and expanding still took 320ms–1.1s. `React.lazy` only resolves its payload the first time the section renders, and React schedules that resolution as its own task — so the click committed an empty `Suspense fallback={null}` and filled it in one or more frames later, even with the module already in memory.

A second expand after collapsing was 17ms, which rules out the sections' own render cost.

## Fix

- `lazy-section.tsx` (new): caches each section's dynamic import and tags the promise with the `status`/`value` fields `use()` reads, so an already-loaded section unwraps synchronously and renders in the same commit as the click. A section still in flight suspends exactly as before.
- `settings-modal.tsx`: starts those imports when the modal opens (P2P stats only when that section is shown).
- `interface-settings.tsx`: same treatment for the nested app-update chunk, warmed at module scope.

Sections stay code split — the main bundle grew 0.03 kB, and opening settings still downloads nothing the user does not expand into.

## Measured

Fresh browser, cold cache, 4× CPU + ~1.6 Mbps / 150 ms latency, expanding one section at a time:

| Section | before | after |
|---|---|---|
| interface | 729ms | 57ms |
| media hosting | 351ms | 97ms |
| subscriptions | 336ms | 54ms |
| board link permissions | 479ms | 47ms |
| advanced | 343ms | 59ms |
| p2p stats | 343ms | 54ms |

Unthrottled: 10–14ms per section (one frame). The only content still arriving late is live P2P peer data inside the stats panel, which is real network data. Cold deep-links (`?section=…` opened before the preload lands) still render, after 521ms on the throttled profile.

## Verification

- `yarn build`, `yarn lint`, `yarn type-check`, `yarn knip`
- 1470 tests pass, including 3 new ones in `lazy-section.test.tsx` (one asserts a preloaded section renders with no Suspense fallback)
- React Doctor 91/100, no findings on changed files
- Desktop + mobile viewport checks in Chrome/Blink, Firefox/Gecko and WebKit/Safari

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only, but it mutates promise `status`/`value` so React `use()` can unwrap synchronously—behavior that depends on React internals and could break on a React upgrade.
> 
> **Overview**
> Removes the blank flash when expanding a settings category even after its chunk is already cached. `React.lazy` only unwraps on first render and React schedules that as a later task, so the click committed an empty `Suspense` fallback.
> 
> Adds `createSectionLoader` / `LazySection`, which cache each dynamic import and stamp the promise with the `status`/`value` fields `use()` reads so a preloaded section renders in the same commit. Settings starts those imports when the modal opens (P2P stats only if shown); the nested app-update chunk is warmed when interface settings loads. Sections stay code-split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9aba5a12ef7ccfd4535262f0664f32bb3e92231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Settings sections now load more smoothly when opening the Settings modal.
  * Commonly used settings content is preloaded to reduce loading delays.
  * Additional sections load on demand while displaying an appropriate loading state.
  * App update settings are preloaded where supported, while remaining unavailable in F-Droid builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->